### PR TITLE
Fix validation errors, passing tests once again

### DIFF
--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -100,6 +100,7 @@ impl VideoSessionShared {
 
             let mut video_decode_capabilities = VideoDecodeCapabilitiesKHR::default();
 
+            // Does this order matter?  It seems to work without relevant validation failures either way.
             let mut video_capabilities = VideoCapabilitiesKHR::default()
                 .push_next(&mut video_decode_capabilities)
                 .push_next(&mut video_decode_h264_capabilities);


### PR DESCRIPTION
Commit b7e216ae80c489b648fc8f169587b5d78cf64fe9 introduced a regression which caused tests to fail.

1. https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkVideoProfileInfoKHR-videoCodecOperation-07179
2. https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07184
3. https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183