### PR TITLE
Introduce MemoryTypeIndex for type safety

### DIFF
--- a/src/physicaldevice.rs
+++ b/src/physicaldevice.rs
@@ -1,3 +1,4 @@
+use crate::allocation::MemoryTypeIndex;
 use crate::error;
 use crate::error::{Error, Variant};
 use crate::instance::{Instance, InstanceShared};
@@ -72,24 +73,24 @@ impl HeapInfos {
         }
     }
 
-    pub fn any_host_visible(&self) -> Option<u32> {
+    pub fn any_host_visible(&self) -> Option<MemoryTypeIndex> {
         for i in 0..self.memory_properties.memory_type_count as usize {
             let memory_type = self.memory_properties.memory_types[i];
 
             if memory_type.property_flags.contains(MemoryPropertyFlags::HOST_VISIBLE) {
-                return Some(i as u32);
+                return Some(MemoryTypeIndex::new(i as u32));
             }
         }
 
         None
     }
 
-    pub fn any_device_local(&self) -> Option<u32> {
+    pub fn any_device_local(&self) -> Option<MemoryTypeIndex> {
         for i in 0..self.memory_properties.memory_type_count as usize {
             let memory_type = self.memory_properties.memory_types[i];
 
             if memory_type.property_flags.contains(MemoryPropertyFlags::DEVICE_LOCAL) {
-                return Some(i as u32);
+                return Some(MemoryTypeIndex::new(i as u32));
             }
         }
 

--- a/src/resources/image.rs
+++ b/src/resources/image.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::allocation::{Allocation, AllocationShared};
+use crate::allocation::{Allocation, AllocationShared, MemoryTypeIndex};
 use ash::vk::{Extent3D, Format, ImageCreateInfo, ImageLayout, ImageTiling, ImageType, ImageUsageFlags, SampleCountFlags};
 
 use crate::device::{Device, DeviceShared};
@@ -25,8 +25,8 @@ impl MemoryRequirements {
         self.alignment
     }
 
-    pub fn any_heap(&self) -> u32 {
-        self.memory_type_bits.trailing_zeros()
+    pub fn any_heap(&self) -> MemoryTypeIndex {
+        MemoryTypeIndex::new(self.memory_type_bits.trailing_zeros())
     }
 }
 

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -1,4 +1,4 @@
-use crate::allocation::Allocation;
+use crate::allocation::{Allocation, MemoryTypeIndex};
 use crate::device::{Device, DeviceShared};
 use crate::error;
 use crate::error::{Error, Variant};
@@ -149,7 +149,7 @@ impl VideoSessionShared {
 
             for (i, r) in video_session_requirements.iter().enumerate() {
                 let supported_types = r.memory_requirements.memory_type_bits;
-                let best_type = supported_types.trailing_zeros(); // TODO: Better logic to select memory type?
+                let best_type = MemoryTypeIndex::new(supported_types.trailing_zeros()); // TODO: Better logic to select memory type?
 
                 let allocation = Allocation::new(device, r.memory_requirements.size, best_type)?;
                 let bind = BindVideoSessionMemoryInfoKHR::default()


### PR DESCRIPTION
Allocation::new accepting a u32 doesn't seem very type safe, what do you think?