### PR TITLE
Fix validation error with new struct to plumb the necessary data

### DIFF
--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -51,6 +51,17 @@ impl DecodeH264 {
             decode_info: *decode_info,
         }
     }
+    fn src_buffer_range(&self) -> u64 {
+        // VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07139
+        // srcBufferRange must be an integer multiple of
+        // VkVideoCapabilitiesKHR::minBitstreamBufferSizeAlignment
+        let alignment = self
+            .shared_parameters
+            .video_session()
+            .capabilities()
+            .min_bitstream_buffer_size_alignment();
+        self.decode_info.size.next_multiple_of(alignment)
+    }
 }
 
 impl AddToCommandBuffer for DecodeH264 {
@@ -133,7 +144,7 @@ impl AddToCommandBuffer for DecodeH264 {
             .push_next(&mut video_decode_info_h264)
             .src_buffer(native_buffer_h264)
             .src_buffer_offset(self.decode_info.offset)
-            .src_buffer_range(self.decode_info.size)
+            .src_buffer_range(self.src_buffer_range())
             // .src_buffer_range(2736)
             .dst_picture_resource(picture_resource_dst)
             .setup_reference_slot(&video_reference_slot);

--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -51,6 +51,17 @@ impl DecodeH264 {
             decode_info: *decode_info,
         }
     }
+    fn src_buffer_offset(&self) -> u64 {
+        // VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07138
+        // srcBufferOffset must be an integer multiple of
+        // VkVideoCapabilitiesKHR::minBitstreamBufferOffsetAlignment
+        let alignment = self
+            .shared_parameters
+            .video_session()
+            .capabilities()
+            .min_bitstream_buffer_offset_alignment();
+        self.decode_info.offset.next_multiple_of(alignment)
+    }
     fn src_buffer_range(&self) -> u64 {
         // VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07139
         // srcBufferRange must be an integer multiple of
@@ -143,7 +154,7 @@ impl AddToCommandBuffer for DecodeH264 {
         let video_decode_info = VideoDecodeInfoKHR::default()
             .push_next(&mut video_decode_info_h264)
             .src_buffer(native_buffer_h264)
-            .src_buffer_offset(self.decode_info.offset)
+            .src_buffer_offset(self.src_buffer_offset())
             .src_buffer_range(self.src_buffer_range())
             // .src_buffer_range(2736)
             .dst_picture_resource(picture_resource_dst)

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -16,17 +16,22 @@ use std::sync::Arc;
 
 pub(crate) struct VideoCapabilities {
     min_bitstream_buffer_size_alignment: u64,
+    min_bitstream_buffer_offset_alignment: u64,
 }
 impl From<VideoCapabilitiesKHR<'_>> for VideoCapabilities {
     fn from(value: VideoCapabilitiesKHR) -> Self {
         Self {
             min_bitstream_buffer_size_alignment: value.min_bitstream_buffer_size_alignment,
+            min_bitstream_buffer_offset_alignment: value.min_bitstream_buffer_offset_alignment,
         }
     }
 }
 impl VideoCapabilities {
     pub(crate) fn min_bitstream_buffer_size_alignment(&self) -> u64 {
         self.min_bitstream_buffer_size_alignment
+    }
+    pub(crate) fn min_bitstream_buffer_offset_alignment(&self) -> u64 {
+        self.min_bitstream_buffer_offset_alignment
     }
 }
 

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -14,6 +14,22 @@ use ash::vk::{
 use std::ptr::{null, null_mut};
 use std::sync::Arc;
 
+pub(crate) struct VideoCapabilities {
+    min_bitstream_buffer_size_alignment: u64,
+}
+impl From<VideoCapabilitiesKHR<'_>> for VideoCapabilities {
+    fn from(value: VideoCapabilitiesKHR) -> Self {
+        Self {
+            min_bitstream_buffer_size_alignment: value.min_bitstream_buffer_size_alignment,
+        }
+    }
+}
+impl VideoCapabilities {
+    pub(crate) fn min_bitstream_buffer_size_alignment(&self) -> u64 {
+        self.min_bitstream_buffer_size_alignment
+    }
+}
+
 pub(crate) struct VideoSessionShared {
     shared_device: Arc<DeviceShared>,
     native_queue_fns: KhrVideoQueueDeviceFn,
@@ -21,6 +37,7 @@ pub(crate) struct VideoSessionShared {
     native_video_instance_fns: InstanceFn,
     native_session: VideoSessionKHR,
     allocations: Vec<Allocation>,
+    capabilities: VideoCapabilities,
 }
 
 impl VideoSessionShared {
@@ -171,6 +188,7 @@ impl VideoSessionShared {
                 native_video_instance_fns: video_instance_fn,
                 native_session,
                 allocations,
+                capabilities: video_capabilities.into(),
             })
         };
         result
@@ -194,6 +212,10 @@ impl VideoSessionShared {
 
     pub(crate) fn device(&self) -> Arc<DeviceShared> {
         self.shared_device.clone()
+    }
+
+    pub(crate) fn capabilities(&self) -> &VideoCapabilities {
+        &self.capabilities
     }
 }
 


### PR DESCRIPTION
VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07139
"srcBufferRange must be an integer multiple of VkVideoCapabilitiesKHR::minBitstreamBufferSizeAlignment"

This fixes the validation error, but at great cost.  How should the data be plumbed to the correct location without being this ugly?