### PR TITLE
Fix validation error vkCmdDecodeVideoKHR-pDecodeInfo-07141

### DIFF
--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -103,7 +103,7 @@ impl AddToCommandBuffer for DecodeH264 {
         let video_reference_slot = VideoReferenceSlotInfoKHR::default()
             .push_next(&mut video_decode_h264_dpb_slot_info)
             .slot_index(0)
-            .picture_resource(&picture_resource_ref);
+            .picture_resource(&picture_resource_dst);
 
         let begin_coding_info = VideoBeginCodingInfoKHR::default()
             .video_session(native_video_session)


### PR DESCRIPTION
`pDecodeInfo->dstPictureResource and pSetupReferenceSlot->pPictureResource do not match`
https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07141

The validation error spews something about VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR, perhaps my gpu has a different capability than yours, and both capabilities need to be implemented?

Both of these have to be implemented since the device is only required to support one:
https://registry.khronos.org/vulkan/specs/latest/man/html/VkVideoDecodeCapabilityFlagBitsKHR.html

Without this change, the `decode_h264` test fails on my hardware.