### PR TITLE
Remove Usages of Arc, Rc, RefCell

### DIFF
--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -21,7 +21,7 @@ pub(crate) struct AllocationShared<'a> {
 }
 
 impl<'a> AllocationShared<'a> {
-	pub fn new(shared_device: &'a DeviceShared<'a>, size: u64, type_index: MemoryTypeIndex) -> Result<Self, Error> {
+    pub fn new(shared_device: &'a DeviceShared<'a>, size: u64, type_index: MemoryTypeIndex) -> Result<Self, Error> {
         let native_device = shared_device.native();
         let info = MemoryAllocateInfo::default().allocation_size(size).memory_type_index(type_index.0);
         let device_memory = unsafe { native_device.allocate_memory(&info, None)? };
@@ -93,17 +93,13 @@ impl<'a> Allocation<'a> {
     pub fn new(device: &'a Device, size: u64, type_index: MemoryTypeIndex) -> Result<Self, Error> {
         let allocation_shared = AllocationShared::new(device.shared(), size, type_index)?;
 
-        Ok(Self {
-            shared: allocation_shared,
-        })
+        Ok(Self { shared: allocation_shared })
     }
 
     pub fn new_external(device: &'a Device, external: *mut c_void, size: u64) -> Result<Self, Error> {
         let allocation_shared = AllocationShared::new_external(device.shared(), external, size)?;
 
-        Ok(Self {
-            shared: allocation_shared,
-        })
+        Ok(Self { shared: allocation_shared })
     }
 
     pub(crate) fn shared(&self) -> &AllocationShared {

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -3,7 +3,6 @@ use crate::error::Error;
 use crate::instance::InstanceShared;
 use ash::vk::{DeviceMemory, ExternalMemoryHandleTypeFlags, ImportMemoryFdInfoKHR, MemoryAllocateInfo};
 use std::ffi::c_void;
-use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryTypeIndex(u32);
@@ -14,15 +13,15 @@ impl MemoryTypeIndex {
 }
 
 pub(crate) struct AllocationShared {
-    shared_instance: Arc<InstanceShared>,
-    shared_device: Arc<DeviceShared>,
+    shared_instance: InstanceShared,
+    shared_device: DeviceShared,
     device_memory: DeviceMemory,
     // size: u64,
     // type_index: MemoryTypeIndex,
 }
 
 impl AllocationShared {
-    pub fn new(shared_device: Arc<DeviceShared>, size: u64, type_index: MemoryTypeIndex) -> Result<Self, Error> {
+    pub fn new(shared_device: DeviceShared, size: u64, type_index: MemoryTypeIndex) -> Result<Self, Error> {
         let native_device = shared_device.native();
         let info = MemoryAllocateInfo::default().allocation_size(size).memory_type_index(type_index.0);
         let device_memory = unsafe { native_device.allocate_memory(&info, None)? };
@@ -36,7 +35,7 @@ impl AllocationShared {
         })
     }
 
-    pub fn new_external(shared_device: Arc<DeviceShared>, external: *mut c_void, size: u64) -> Result<Self, Error> {
+    pub fn new_external(shared_device: DeviceShared, external: *mut c_void, size: u64) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let mut todo_bad = ImportMemoryFdInfoKHR::default()
@@ -62,11 +61,11 @@ impl AllocationShared {
     }
 
     #[expect(unused)]
-    pub(crate) fn instance(&self) -> Arc<InstanceShared> {
+    pub(crate) fn instance(&self) -> InstanceShared {
         self.shared_instance.clone()
     }
 
-    pub(crate) fn device(&self) -> Arc<DeviceShared> {
+    pub(crate) fn device(&self) -> DeviceShared {
         self.shared_device.clone()
     }
 
@@ -87,7 +86,7 @@ impl Drop for AllocationShared {
 
 /// An allocation on a host or device.
 pub struct Allocation {
-    shared: Arc<AllocationShared>,
+    shared: AllocationShared,
 }
 
 impl Allocation {
@@ -95,7 +94,7 @@ impl Allocation {
         let allocation_shared = AllocationShared::new(device.shared(), size, type_index)?;
 
         Ok(Self {
-            shared: Arc::new(allocation_shared),
+            shared: allocation_shared,
         })
     }
 
@@ -103,11 +102,11 @@ impl Allocation {
         let allocation_shared = AllocationShared::new_external(device.shared(), external, size)?;
 
         Ok(Self {
-            shared: Arc::new(allocation_shared),
+            shared: allocation_shared,
         })
     }
 
-    pub(crate) fn shared(&self) -> Arc<AllocationShared> {
+    pub(crate) fn shared(&self) -> AllocationShared {
         self.shared.clone()
     }
 

--- a/src/allocation.rs
+++ b/src/allocation.rs
@@ -65,7 +65,7 @@ impl<'a> AllocationShared<'a> {
         &self.shared_instance
     }
 
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared_device
     }
 
@@ -102,7 +102,7 @@ impl<'a> Allocation<'a> {
         Ok(Self { shared: allocation_shared })
     }
 
-    pub(crate) fn shared(&self) -> &AllocationShared {
+    pub(crate) fn shared(&self) -> &AllocationShared<'_> {
         &self.shared
     }
 

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -71,7 +71,7 @@ impl<'a> CommandBuffer<'a> {
         self.shared.native()
     }
 
-    pub(crate) fn shared(&self) -> &CommandBufferShared {
+    pub(crate) fn shared(&self) -> &CommandBufferShared<'_> {
         &self.shared
     }
 }

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -2,16 +2,15 @@ use crate::device::{Device, DeviceShared};
 use crate::error;
 use crate::error::{Error, Variant};
 use ash::vk::{CommandBufferAllocateInfo, CommandBufferLevel, CommandPoolCreateFlags, CommandPoolCreateInfo};
-use std::sync::Arc;
 
 pub(crate) struct CommandBufferShared {
-    shared_device: Arc<DeviceShared>,
+    shared_device: DeviceShared,
     native_command_pool: ash::vk::CommandPool,
     native_command_buffer: ash::vk::CommandBuffer,
 }
 
 impl CommandBufferShared {
-    pub fn new(shared_device: Arc<DeviceShared>, queue_family_index: u32) -> Result<Self, Error> {
+    pub fn new(shared_device: DeviceShared, queue_family_index: u32) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let command_pool_create_info = CommandPoolCreateInfo::default()
@@ -57,14 +56,14 @@ impl Drop for CommandBufferShared {
 
 /// Stores commands related to a specific queue family.
 pub struct CommandBuffer {
-    shared: Arc<CommandBufferShared>,
+    shared: CommandBufferShared,
 }
 
 impl CommandBuffer {
     pub fn new(device: &Device, queue_family_index: u32) -> Result<Self, Error> {
         let shared = CommandBufferShared::new(device.shared(), queue_family_index)?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
     #[expect(unused)]
@@ -72,7 +71,7 @@ impl CommandBuffer {
         self.shared.native()
     }
 
-    pub(crate) fn shared(&self) -> Arc<CommandBufferShared> {
+    pub(crate) fn shared(&self) -> CommandBufferShared {
         self.shared.clone()
     }
 }

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -3,14 +3,14 @@ use crate::error;
 use crate::error::{Error, Variant};
 use ash::vk::{CommandBufferAllocateInfo, CommandBufferLevel, CommandPoolCreateFlags, CommandPoolCreateInfo};
 
-pub(crate) struct CommandBufferShared {
-    shared_device: DeviceShared,
+pub(crate) struct CommandBufferShared<'a> {
+	shared_device: &'a DeviceShared<'a>,
     native_command_pool: ash::vk::CommandPool,
     native_command_buffer: ash::vk::CommandBuffer,
 }
 
-impl CommandBufferShared {
-    pub fn new(shared_device: DeviceShared, queue_family_index: u32) -> Result<Self, Error> {
+impl<'a> CommandBufferShared<'a> {
+	pub fn new(shared_device: &'a DeviceShared<'a>, queue_family_index: u32) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let command_pool_create_info = CommandPoolCreateInfo::default()
@@ -43,7 +43,7 @@ impl CommandBufferShared {
     }
 }
 
-impl Drop for CommandBufferShared {
+impl<'a> Drop for CommandBufferShared<'a> {
     fn drop(&mut self) {
         let device = self.shared_device.native();
 
@@ -55,12 +55,12 @@ impl Drop for CommandBufferShared {
 }
 
 /// Stores commands related to a specific queue family.
-pub struct CommandBuffer {
-    shared: CommandBufferShared,
+pub struct CommandBuffer<'a> {
+    shared: CommandBufferShared<'a>,
 }
 
-impl CommandBuffer {
-    pub fn new(device: &Device, queue_family_index: u32) -> Result<Self, Error> {
+impl<'a> CommandBuffer<'a> {
+    pub fn new(device: &'a Device, queue_family_index: u32) -> Result<Self, Error> {
         let shared = CommandBufferShared::new(device.shared(), queue_family_index)?;
 
         Ok(Self { shared })
@@ -71,8 +71,8 @@ impl CommandBuffer {
         self.shared.native()
     }
 
-    pub(crate) fn shared(&self) -> CommandBufferShared {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &CommandBufferShared {
+        &self.shared
     }
 }
 

--- a/src/commandbuffer.rs
+++ b/src/commandbuffer.rs
@@ -4,13 +4,13 @@ use crate::error::{Error, Variant};
 use ash::vk::{CommandBufferAllocateInfo, CommandBufferLevel, CommandPoolCreateFlags, CommandPoolCreateInfo};
 
 pub(crate) struct CommandBufferShared<'a> {
-	shared_device: &'a DeviceShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     native_command_pool: ash::vk::CommandPool,
     native_command_buffer: ash::vk::CommandBuffer,
 }
 
 impl<'a> CommandBufferShared<'a> {
-	pub fn new(shared_device: &'a DeviceShared<'a>, queue_family_index: u32) -> Result<Self, Error> {
+    pub fn new(shared_device: &'a DeviceShared<'a>, queue_family_index: u32) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let command_pool_create_info = CommandPoolCreateInfo::default()

--- a/src/device.rs
+++ b/src/device.rs
@@ -93,17 +93,13 @@ impl<'a> Device<'a> {
     pub fn new_with_families(physical_device: &'a PhysicalDevice, queue_families: &[u32]) -> Result<Self, Error> {
         let device_shared = DeviceShared::new_with_families(physical_device.shared(), queue_families)?;
 
-        Ok(Self {
-            shared: device_shared,
-        })
+        Ok(Self { shared: device_shared })
     }
 
     pub fn new(physical_device: &'a PhysicalDevice) -> Result<Self, Error> {
         let device_shared = DeviceShared::new(physical_device.shared())?;
 
-        Ok(Self {
-            shared: device_shared,
-        })
+        Ok(Self { shared: device_shared })
     }
 
     pub(crate) fn shared(&self) -> &DeviceShared {

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,15 +3,14 @@ use crate::error::{Error, Variant};
 use crate::instance::InstanceShared;
 use crate::physicaldevice::{PhysicalDevice, PhysicalDeviceShared};
 use ash::vk::{DeviceCreateInfo, DeviceQueueCreateInfo, PhysicalDeviceFeatures2, PhysicalDeviceSynchronization2Features};
-use std::sync::Arc;
 
 pub(crate) struct DeviceShared {
     native_device: ash::Device,
-    shared_physical_device: Arc<PhysicalDeviceShared>,
+    shared_physical_device: PhysicalDeviceShared,
 }
 
 impl DeviceShared {
-    pub(crate) fn new_with_families(shared_physical_device: Arc<PhysicalDeviceShared>, queue_families: &[u32]) -> Result<Self, Error> {
+    pub(crate) fn new_with_families(shared_physical_device: PhysicalDeviceShared, queue_families: &[u32]) -> Result<Self, Error> {
         let native_instance = shared_physical_device.instance().native();
 
         // SAFETY: Should be safe as native instance is valid.
@@ -57,17 +56,18 @@ impl DeviceShared {
         }
     }
 
-    pub(crate) fn new(shared_physical_device: Arc<PhysicalDeviceShared>) -> Result<Self, Error> {
+    pub(crate) fn new(shared_physical_device: PhysicalDeviceShared) -> Result<Self, Error> {
         let infos = shared_physical_device.queue_family_infos().available().to_vec();
 
         Self::new_with_families(shared_physical_device, &infos)
     }
 
-    pub(crate) fn physical_device(&self) -> Arc<PhysicalDeviceShared> {
+    #[expect(unused)]
+    pub(crate) fn physical_device(&self) -> PhysicalDeviceShared {
         self.shared_physical_device.clone()
     }
 
-    pub(crate) fn instance(&self) -> Arc<InstanceShared> {
+    pub(crate) fn instance(&self) -> InstanceShared {
         self.shared_physical_device.instance()
     }
 
@@ -86,7 +86,7 @@ impl Drop for DeviceShared {
 
 /// Logical Vulkan device linked to some [`PhysicalDevice`](PhysicalDevice).
 pub struct Device {
-    shared: Arc<DeviceShared>,
+    shared: DeviceShared,
 }
 
 impl Device {
@@ -94,7 +94,7 @@ impl Device {
         let device_shared = DeviceShared::new_with_families(physical_device.shared(), queue_families)?;
 
         Ok(Self {
-            shared: Arc::new(device_shared),
+            shared: device_shared,
         })
     }
 
@@ -102,11 +102,11 @@ impl Device {
         let device_shared = DeviceShared::new(physical_device.shared())?;
 
         Ok(Self {
-            shared: Arc::new(device_shared),
+            shared: device_shared,
         })
     }
 
-    pub(crate) fn shared(&self) -> Arc<DeviceShared> {
+    pub(crate) fn shared(&self) -> DeviceShared {
         self.shared.clone()
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,13 +4,13 @@ use crate::instance::InstanceShared;
 use crate::physicaldevice::{PhysicalDevice, PhysicalDeviceShared};
 use ash::vk::{DeviceCreateInfo, DeviceQueueCreateInfo, PhysicalDeviceFeatures2, PhysicalDeviceSynchronization2Features};
 
-pub(crate) struct DeviceShared {
+pub(crate) struct DeviceShared<'a> {
     native_device: ash::Device,
-    shared_physical_device: PhysicalDeviceShared,
+    shared_physical_device: &'a PhysicalDeviceShared<'a>,
 }
 
-impl DeviceShared {
-    pub(crate) fn new_with_families(shared_physical_device: PhysicalDeviceShared, queue_families: &[u32]) -> Result<Self, Error> {
+impl<'a> DeviceShared<'a> {
+    pub(crate) fn new_with_families(shared_physical_device: &'a PhysicalDeviceShared, queue_families: &[u32]) -> Result<Self, Error> {
         let native_instance = shared_physical_device.instance().native();
 
         // SAFETY: Should be safe as native instance is valid.
@@ -56,27 +56,27 @@ impl DeviceShared {
         }
     }
 
-    pub(crate) fn new(shared_physical_device: PhysicalDeviceShared) -> Result<Self, Error> {
+    pub(crate) fn new(shared_physical_device: &'a PhysicalDeviceShared) -> Result<Self, Error> {
         let infos = shared_physical_device.queue_family_infos().available().to_vec();
 
         Self::new_with_families(shared_physical_device, &infos)
     }
 
     #[expect(unused)]
-    pub(crate) fn physical_device(&self) -> PhysicalDeviceShared {
-        self.shared_physical_device.clone()
+    pub(crate) fn physical_device(&self) -> &PhysicalDeviceShared {
+        &self.shared_physical_device
     }
 
-    pub(crate) fn instance(&self) -> InstanceShared {
+    pub(crate) fn instance(&self) -> &InstanceShared {
         self.shared_physical_device.instance()
     }
 
-    pub(crate) fn native(&self) -> ash::Device {
-        self.native_device.clone()
+    pub(crate) fn native(&self) -> &ash::Device {
+        &self.native_device
     }
 }
 
-impl Drop for DeviceShared {
+impl<'a> Drop for DeviceShared<'a> {
     fn drop(&mut self) {
         unsafe {
             self.native_device.destroy_device(None);
@@ -85,12 +85,12 @@ impl Drop for DeviceShared {
 }
 
 /// Logical Vulkan device linked to some [`PhysicalDevice`](PhysicalDevice).
-pub struct Device {
-    shared: DeviceShared,
+pub struct Device<'a> {
+    shared: DeviceShared<'a>,
 }
 
-impl Device {
-    pub fn new_with_families(physical_device: &PhysicalDevice, queue_families: &[u32]) -> Result<Self, Error> {
+impl<'a> Device<'a> {
+    pub fn new_with_families(physical_device: &'a PhysicalDevice, queue_families: &[u32]) -> Result<Self, Error> {
         let device_shared = DeviceShared::new_with_families(physical_device.shared(), queue_families)?;
 
         Ok(Self {
@@ -98,7 +98,7 @@ impl Device {
         })
     }
 
-    pub fn new(physical_device: &PhysicalDevice) -> Result<Self, Error> {
+    pub fn new(physical_device: &'a PhysicalDevice) -> Result<Self, Error> {
         let device_shared = DeviceShared::new(physical_device.shared())?;
 
         Ok(Self {
@@ -106,8 +106,8 @@ impl Device {
         })
     }
 
-    pub(crate) fn shared(&self) -> DeviceShared {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &DeviceShared {
+        &self.shared
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -63,7 +63,7 @@ impl<'a> DeviceShared<'a> {
     }
 
     #[expect(unused)]
-    pub(crate) fn physical_device(&self) -> &PhysicalDeviceShared {
+    pub(crate) fn physical_device(&self) -> &PhysicalDeviceShared<'_> {
         &self.shared_physical_device
     }
 
@@ -102,7 +102,7 @@ impl<'a> Device<'a> {
         Ok(Self { shared: device_shared })
     }
 
-    pub(crate) fn shared(&self) -> &DeviceShared {
+    pub(crate) fn shared(&self) -> &DeviceShared<'_> {
         &self.shared
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2,7 +2,6 @@ use crate::error::Error;
 use ash::vk;
 use ash::vk::{ApplicationInfo, InstanceCreateFlags, InstanceCreateInfo};
 use std::ffi::CString;
-use std::sync::Arc;
 
 /// Stores information (e.g., app name, version) about the current instance.
 #[derive(Debug)]
@@ -114,17 +113,17 @@ impl Drop for InstanceShared {
 
 /// The Vulkan driver instance, **start here**.
 pub struct Instance {
-    shared: Arc<InstanceShared>,
+    shared: InstanceShared,
 }
 
 impl Instance {
     pub fn new(info: &InstanceInfo) -> Result<Self, Error> {
         Ok(Self {
-            shared: Arc::new(InstanceShared::new(info)?),
+            shared: InstanceShared::new(info)?,
         })
     }
 
-    pub(crate) fn shared(&self) -> Arc<InstanceShared> {
+    pub(crate) fn shared(&self) -> InstanceShared {
         self.shared.clone()
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -94,12 +94,12 @@ impl InstanceShared {
         }
     }
 
-    pub fn native(&self) -> ash::Instance {
-        self.instance.clone()
+    pub fn native(&self) -> &ash::Instance {
+        &self.instance
     }
 
-    pub fn native_entry(&self) -> ash::Entry {
-        self.entry.clone()
+    pub fn native_entry(&self) -> &ash::Entry {
+        &self.entry
     }
 }
 
@@ -123,8 +123,8 @@ impl Instance {
         })
     }
 
-    pub(crate) fn shared(&self) -> InstanceShared {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &InstanceShared {
+        &self.shared
     }
 }
 

--- a/src/ops/compute.rs
+++ b/src/ops/compute.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ash::vk::{
     AccessFlags, BufferMemoryBarrier, DependencyFlags, DescriptorBufferInfo, DescriptorImageInfo, DescriptorPool, DescriptorPoolCreateInfo,
     DescriptorPoolSize, DescriptorSet, DescriptorSetAllocateInfo, DescriptorType, ImageAspectFlags, ImageLayout, ImageMemoryBarrier,
@@ -13,7 +11,7 @@ use crate::shader::{ParameterType, Pipeline, PipelineShared, ShaderParameterSet}
 
 /// Run a compute shader.
 pub struct Compute<T> {
-    shared_pipeline: Arc<PipelineShared<T>>,
+    shared_pipeline: PipelineShared<T>,
     dispatch_groups: (u32, u32, u32),
     native_descriptor_pool: DescriptorPool,
     native_descriptor_sets: Vec<DescriptorSet>,

--- a/src/ops/compute.rs
+++ b/src/ops/compute.rs
@@ -10,16 +10,16 @@ use crate::queue::CommandBuilder;
 use crate::shader::{ParameterType, Pipeline, PipelineShared, ShaderParameterSet};
 
 /// Run a compute shader.
-pub struct Compute<T> {
-    shared_pipeline: PipelineShared<T>,
+pub struct Compute<'a,T> {
+    shared_pipeline: &'a PipelineShared<'a,T>,
     dispatch_groups: (u32, u32, u32),
     native_descriptor_pool: DescriptorPool,
     native_descriptor_sets: Vec<DescriptorSet>,
     params: T,
 }
 
-impl<T: ShaderParameterSet> Compute<T> {
-    pub fn new(pipeline: &Pipeline<T>, params: T, dispatch_groups: (u32, u32, u32)) -> Result<Self, Error> {
+impl<'a,T: ShaderParameterSet> Compute<'a,T> {
+    pub fn new(pipeline: &'a Pipeline<T>, params: T, dispatch_groups: (u32, u32, u32)) -> Result<Self, Error> {
         let shared_pipeline = pipeline.shared();
         let shared_parameters = shared_pipeline.parameters();
         let native_device = shared_pipeline.device().native();
@@ -52,7 +52,7 @@ impl<T: ShaderParameterSet> Compute<T> {
     }
 }
 
-impl<T> Drop for Compute<T> {
+impl<'a,T> Drop for Compute<'a,T> {
     fn drop(&mut self) {
         unsafe {
             let native_device = self.shared_pipeline.device().native();
@@ -62,7 +62,7 @@ impl<T> Drop for Compute<T> {
     }
 }
 
-impl<T: ShaderParameterSet> AddToCommandBuffer for Compute<T> {
+impl<'a,T: ShaderParameterSet> AddToCommandBuffer for Compute<'a,T> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let native_device = self.shared_pipeline.device().native();
         let native_command_buffer = builder.native_command_buffer();

--- a/src/ops/compute.rs
+++ b/src/ops/compute.rs
@@ -10,15 +10,15 @@ use crate::queue::CommandBuilder;
 use crate::shader::{ParameterType, Pipeline, PipelineShared, ShaderParameterSet};
 
 /// Run a compute shader.
-pub struct Compute<'a,T> {
-    shared_pipeline: &'a PipelineShared<'a,T>,
+pub struct Compute<'a, T> {
+    shared_pipeline: &'a PipelineShared<'a, T>,
     dispatch_groups: (u32, u32, u32),
     native_descriptor_pool: DescriptorPool,
     native_descriptor_sets: Vec<DescriptorSet>,
     params: T,
 }
 
-impl<'a,T: ShaderParameterSet> Compute<'a,T> {
+impl<'a, T: ShaderParameterSet> Compute<'a, T> {
     pub fn new(pipeline: &'a Pipeline<T>, params: T, dispatch_groups: (u32, u32, u32)) -> Result<Self, Error> {
         let shared_pipeline = pipeline.shared();
         let shared_parameters = shared_pipeline.parameters();
@@ -52,7 +52,7 @@ impl<'a,T: ShaderParameterSet> Compute<'a,T> {
     }
 }
 
-impl<'a,T> Drop for Compute<'a,T> {
+impl<'a, T> Drop for Compute<'a, T> {
     fn drop(&mut self) {
         unsafe {
             let native_device = self.shared_pipeline.device().native();
@@ -62,7 +62,7 @@ impl<'a,T> Drop for Compute<'a,T> {
     }
 }
 
-impl<'a,T: ShaderParameterSet> AddToCommandBuffer for Compute<'a,T> {
+impl<'a, T: ShaderParameterSet> AddToCommandBuffer for Compute<'a, T> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let native_device = self.shared_pipeline.device().native();
         let native_command_buffer = builder.native_command_buffer();

--- a/src/ops/copyb2b.rs
+++ b/src/ops/copyb2b.rs
@@ -5,14 +5,14 @@ use crate::resources::{Buffer, BufferShared};
 use ash::vk::BufferCopy;
 
 /// Performs a buffer-to-buffer copy operation.
-pub struct CopyBuffer2Buffer {
-    source: BufferShared,
-    destination: BufferShared,
+pub struct CopyBuffer2Buffer<'a> {
+	source: &'a BufferShared<'a>,
+	destination: &'a BufferShared<'a>,
     size: u64,
 }
 
-impl CopyBuffer2Buffer {
-    pub fn new(source: &Buffer, destination: &Buffer, size: u64) -> Self {
+impl<'a> CopyBuffer2Buffer<'a> {
+    pub fn new(source: &'a Buffer<'a>, destination: &'a Buffer<'a>, size: u64) -> Self {
         Self {
             source: source.shared(),
             destination: destination.shared(),
@@ -21,7 +21,7 @@ impl CopyBuffer2Buffer {
     }
 }
 
-impl AddToCommandBuffer for CopyBuffer2Buffer {
+impl<'a> AddToCommandBuffer for CopyBuffer2Buffer<'a> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let native_device = self.source.device().native();
         let native_command_buffer = builder.native_command_buffer();

--- a/src/ops/copyb2b.rs
+++ b/src/ops/copyb2b.rs
@@ -3,12 +3,11 @@ use crate::ops::AddToCommandBuffer;
 use crate::queue::CommandBuilder;
 use crate::resources::{Buffer, BufferShared};
 use ash::vk::BufferCopy;
-use std::sync::Arc;
 
 /// Performs a buffer-to-buffer copy operation.
 pub struct CopyBuffer2Buffer {
-    source: Arc<BufferShared>,
-    destination: Arc<BufferShared>,
+    source: BufferShared,
+    destination: BufferShared,
     size: u64,
 }
 

--- a/src/ops/copyb2b.rs
+++ b/src/ops/copyb2b.rs
@@ -6,8 +6,8 @@ use ash::vk::BufferCopy;
 
 /// Performs a buffer-to-buffer copy operation.
 pub struct CopyBuffer2Buffer<'a> {
-	source: &'a BufferShared<'a>,
-	destination: &'a BufferShared<'a>,
+    source: &'a BufferShared<'a>,
+    destination: &'a BufferShared<'a>,
     size: u64,
 }
 

--- a/src/ops/copyi2b.rs
+++ b/src/ops/copyi2b.rs
@@ -6,8 +6,8 @@ use ash::vk::{BufferImageCopy, ImageAspectFlags, ImageLayout, ImageSubresourceLa
 
 /// Performs an image-to-buffer copy operation.
 pub struct CopyImage2Buffer<'a> {
-	image: &'a ImageShared<'a>,
-	buffer: &'a BufferShared<'a>,
+    image: &'a ImageShared<'a>,
+    buffer: &'a BufferShared<'a>,
     aspect_mask: ImageAspectFlags,
 }
 

--- a/src/ops/copyi2b.rs
+++ b/src/ops/copyi2b.rs
@@ -5,14 +5,14 @@ use crate::resources::{Buffer, BufferShared, Image, ImageShared};
 use ash::vk::{BufferImageCopy, ImageAspectFlags, ImageLayout, ImageSubresourceLayers};
 
 /// Performs an image-to-buffer copy operation.
-pub struct CopyImage2Buffer {
-    image: ImageShared,
-    buffer: BufferShared,
+pub struct CopyImage2Buffer<'a> {
+	image: &'a ImageShared<'a>,
+	buffer: &'a BufferShared<'a>,
     aspect_mask: ImageAspectFlags,
 }
 
-impl CopyImage2Buffer {
-    pub fn new(image: &Image, buffer: &Buffer, aspect_mask: ImageAspectFlags) -> Self {
+impl<'a> CopyImage2Buffer<'a> {
+    pub fn new(image: &'a Image<'a>, buffer: &'a Buffer<'a>, aspect_mask: ImageAspectFlags) -> Self {
         Self {
             image: image.shared(),
             buffer: buffer.shared(),
@@ -21,7 +21,7 @@ impl CopyImage2Buffer {
     }
 }
 
-impl AddToCommandBuffer for CopyImage2Buffer {
+impl<'a> AddToCommandBuffer for CopyImage2Buffer<'a> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let native_device = self.image.device().native();
         let native_command_buffer = builder.native_command_buffer();

--- a/src/ops/copyi2b.rs
+++ b/src/ops/copyi2b.rs
@@ -3,13 +3,11 @@ use crate::ops::AddToCommandBuffer;
 use crate::queue::CommandBuilder;
 use crate::resources::{Buffer, BufferShared, Image, ImageShared};
 use ash::vk::{BufferImageCopy, ImageAspectFlags, ImageLayout, ImageSubresourceLayers};
-use std::rc::Rc;
-use std::sync::Arc;
 
 /// Performs an image-to-buffer copy operation.
 pub struct CopyImage2Buffer {
-    image: Rc<ImageShared>,
-    buffer: Arc<BufferShared>,
+    image: ImageShared,
+    buffer: BufferShared,
     aspect_mask: ImageAspectFlags,
 }
 

--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -28,20 +28,20 @@ impl DecodeInfo {
 }
 
 /// Decode a H.264 video frame.
-pub struct DecodeH264 {
-    shared_parameters: VideoSessionParametersShared,
-    shared_buffer: BufferShared,
-    shared_image_view: ImageViewShared,
-    shared_ref_view: ImageViewShared,
+pub struct DecodeH264<'a> {
+	shared_parameters: &'a VideoSessionParametersShared<'a>,
+	shared_buffer: &'a BufferShared<'a>,
+	shared_image_view: &'a ImageViewShared<'a>,
+	shared_ref_view: &'a ImageViewShared<'a>,
     decode_info: DecodeInfo,
 }
 
-impl DecodeH264 {
+impl<'a> DecodeH264<'a> {
     pub fn new(
-        buffer: &Buffer,
-        video_session_parameters: &VideoSessionParameters,
-        target_view: &ImageView,
-        ref_view: &ImageView,
+        buffer: &'a Buffer,
+        video_session_parameters: &'a VideoSessionParameters,
+        target_view: &'a ImageView,
+        ref_view: &'a ImageView,
         decode_info: &DecodeInfo,
     ) -> Self {
         Self {
@@ -54,7 +54,7 @@ impl DecodeH264 {
     }
 }
 
-impl AddToCommandBuffer for DecodeH264 {
+impl<'a> AddToCommandBuffer for DecodeH264<'a> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let shared_video_session = self.shared_parameters.video_session();
 

--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -13,8 +13,6 @@ use ash::vk::{
     VideoDecodeCapabilityFlagsKHR, VideoDecodeH264DpbSlotInfoKHR, VideoDecodeH264PictureInfoKHR, VideoDecodeInfoKHR, VideoEndCodingInfoKHR,
     VideoPictureResourceInfoKHR, VideoReferenceSlotInfoKHR, QUEUE_FAMILY_IGNORED,
 };
-use std::rc::Rc;
-use std::sync::Arc;
 
 /// Specifies which part of a buffer to decode.
 #[derive(Copy, Clone)]
@@ -31,10 +29,10 @@ impl DecodeInfo {
 
 /// Decode a H.264 video frame.
 pub struct DecodeH264 {
-    shared_parameters: Arc<VideoSessionParametersShared>,
-    shared_buffer: Arc<BufferShared>,
-    shared_image_view: Rc<ImageViewShared>,
-    shared_ref_view: Rc<ImageViewShared>,
+    shared_parameters: VideoSessionParametersShared,
+    shared_buffer: BufferShared,
+    shared_image_view: ImageViewShared,
+    shared_ref_view: ImageViewShared,
     decode_info: DecodeInfo,
 }
 

--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -29,10 +29,10 @@ impl DecodeInfo {
 
 /// Decode a H.264 video frame.
 pub struct DecodeH264<'a> {
-	shared_parameters: &'a VideoSessionParametersShared<'a>,
-	shared_buffer: &'a BufferShared<'a>,
-	shared_image_view: &'a ImageViewShared<'a>,
-	shared_ref_view: &'a ImageViewShared<'a>,
+    shared_parameters: &'a VideoSessionParametersShared<'a>,
+    shared_buffer: &'a BufferShared<'a>,
+    shared_image_view: &'a ImageViewShared<'a>,
+    shared_ref_view: &'a ImageViewShared<'a>,
     decode_info: DecodeInfo,
 }
 

--- a/src/ops/fill.rs
+++ b/src/ops/fill.rs
@@ -7,7 +7,7 @@ use ash::vk::{DependencyFlags, PipelineStageFlags, WHOLE_SIZE};
 
 /// Fills a buffer with a fixed value.
 pub struct FillBuffer<'a> {
-	buffer: &'a BufferShared<'a>,
+    buffer: &'a BufferShared<'a>,
     value: u32,
 }
 

--- a/src/ops/fill.rs
+++ b/src/ops/fill.rs
@@ -6,13 +6,13 @@ use ash::vk;
 use ash::vk::{DependencyFlags, PipelineStageFlags, WHOLE_SIZE};
 
 /// Fills a buffer with a fixed value.
-pub struct FillBuffer {
-    buffer: BufferShared,
+pub struct FillBuffer<'a> {
+	buffer: &'a BufferShared<'a>,
     value: u32,
 }
 
-impl FillBuffer {
-    pub fn new(buffer: &Buffer, value: u32) -> Self {
+impl<'a> FillBuffer<'a> {
+    pub fn new(buffer: &'a Buffer, value: u32) -> Self {
         Self {
             buffer: buffer.shared(),
             value,
@@ -20,7 +20,7 @@ impl FillBuffer {
     }
 }
 
-impl AddToCommandBuffer for FillBuffer {
+impl<'a> AddToCommandBuffer for FillBuffer<'a> {
     fn run_in(&self, builder: &mut CommandBuilder) -> Result<(), Error> {
         let native_device = self.buffer.device().native();
         let native_buffer = self.buffer.native();

--- a/src/ops/fill.rs
+++ b/src/ops/fill.rs
@@ -4,11 +4,10 @@ use crate::queue::CommandBuilder;
 use crate::resources::{Buffer, BufferShared};
 use ash::vk;
 use ash::vk::{DependencyFlags, PipelineStageFlags, WHOLE_SIZE};
-use std::sync::Arc;
 
 /// Fills a buffer with a fixed value.
 pub struct FillBuffer {
-    buffer: Arc<BufferShared>,
+    buffer: BufferShared,
     value: u32,
 }
 

--- a/src/physicaldevice.rs
+++ b/src/physicaldevice.rs
@@ -3,7 +3,6 @@ use crate::error;
 use crate::error::{Error, Variant};
 use crate::instance::{Instance, InstanceShared};
 use ash::vk::{MemoryPropertyFlags, PhysicalDeviceMemoryProperties, QueueFlags};
-use std::sync::Arc;
 
 /// Provides logical information about vulkan queue families.
 pub struct QueueFamilyInfos {
@@ -100,13 +99,13 @@ impl HeapInfos {
 
 pub(crate) struct PhysicalDeviceShared {
     native_physical_device: ash::vk::PhysicalDevice,
-    shared_instance: Arc<InstanceShared>,
+    shared_instance: InstanceShared,
     queue_family_infos: QueueFamilyInfos,
     heap_infos: HeapInfos,
 }
 
 impl PhysicalDeviceShared {
-    pub fn new_any(shared_instance: Arc<InstanceShared>) -> Result<Self, Error> {
+    pub fn new_any(shared_instance: InstanceShared) -> Result<Self, Error> {
         let native_instance = shared_instance.native();
 
         unsafe {
@@ -129,7 +128,7 @@ impl PhysicalDeviceShared {
         self.native_physical_device
     }
 
-    pub(crate) fn instance(&self) -> Arc<InstanceShared> {
+    pub(crate) fn instance(&self) -> InstanceShared {
         self.shared_instance.clone()
     }
 
@@ -144,17 +143,17 @@ impl PhysicalDeviceShared {
 
 /// Some GPU in your system.
 pub struct PhysicalDevice {
-    shared: Arc<PhysicalDeviceShared>,
+    shared: PhysicalDeviceShared,
 }
 
 impl PhysicalDevice {
     pub fn new_any(instance: &Instance) -> Result<Self, Error> {
         let shared = PhysicalDeviceShared::new_any(instance.shared())?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> Arc<PhysicalDeviceShared> {
+    pub(crate) fn shared(&self) -> PhysicalDeviceShared {
         self.shared.clone()
     }
 

--- a/src/physicaldevice.rs
+++ b/src/physicaldevice.rs
@@ -153,7 +153,7 @@ impl<'a> PhysicalDevice<'a> {
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> &PhysicalDeviceShared {
+    pub(crate) fn shared(&self) -> &PhysicalDeviceShared<'_> {
         &self.shared
     }
 

--- a/src/physicaldevice.rs
+++ b/src/physicaldevice.rs
@@ -97,15 +97,15 @@ impl HeapInfos {
     }
 }
 
-pub(crate) struct PhysicalDeviceShared {
+pub(crate) struct PhysicalDeviceShared<'a> {
     native_physical_device: ash::vk::PhysicalDevice,
-    shared_instance: InstanceShared,
+    shared_instance: &'a InstanceShared,
     queue_family_infos: QueueFamilyInfos,
     heap_infos: HeapInfos,
 }
 
-impl PhysicalDeviceShared {
-    pub fn new_any(shared_instance: InstanceShared) -> Result<Self, Error> {
+impl<'a> PhysicalDeviceShared<'a> {
+    pub fn new_any(shared_instance: &'a InstanceShared) -> Result<Self, Error> {
         let native_instance = shared_instance.native();
 
         unsafe {
@@ -128,8 +128,8 @@ impl PhysicalDeviceShared {
         self.native_physical_device
     }
 
-    pub(crate) fn instance(&self) -> InstanceShared {
-        self.shared_instance.clone()
+    pub(crate) fn instance(&self) -> &InstanceShared {
+        &self.shared_instance
     }
 
     pub fn queue_family_infos(&self) -> &QueueFamilyInfos {
@@ -142,19 +142,19 @@ impl PhysicalDeviceShared {
 }
 
 /// Some GPU in your system.
-pub struct PhysicalDevice {
-    shared: PhysicalDeviceShared,
+pub struct PhysicalDevice<'a> {
+    shared: PhysicalDeviceShared<'a>,
 }
 
-impl PhysicalDevice {
-    pub fn new_any(instance: &Instance) -> Result<Self, Error> {
+impl<'a> PhysicalDevice<'a> {
+    pub fn new_any(instance: &'a Instance) -> Result<Self, Error> {
         let shared = PhysicalDeviceShared::new_any(instance.shared())?;
 
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> PhysicalDeviceShared {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &PhysicalDeviceShared {
+        &self.shared
     }
 
     pub fn queue_family_infos(&self) -> &QueueFamilyInfos {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -23,7 +23,7 @@ impl<'a> CommandBuilder<'a> {
 }
 
 struct QueueShared<'a> {
-	shared_device: &'a DeviceShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     native_queue: ash::vk::Queue,
     queue_family_index: u32,
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use ash::vk::{CommandBufferBeginInfo, CommandBufferResetFlags, FenceCreateFlags, FenceCreateInfo, SubmitInfo};
 
@@ -24,13 +23,13 @@ impl<'a> CommandBuilder<'a> {
 }
 
 struct QueueShared {
-    shared_device: Arc<DeviceShared>,
+    shared_device: DeviceShared,
     native_queue: ash::vk::Queue,
     queue_family_index: u32,
 }
 
 impl QueueShared {
-    fn new(shared_device: Arc<DeviceShared>, queue_family_index: u32, index: u32) -> Result<Self, Error> {
+    fn new(shared_device: DeviceShared, queue_family_index: u32, index: u32) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         unsafe {
@@ -46,7 +45,7 @@ impl QueueShared {
 
     pub fn build_and_submit(
         &self,
-        command_buffer: Arc<CommandBufferShared>,
+        command_buffer: CommandBufferShared,
         f: impl FnOnce(&mut CommandBuilder) -> Result<(), Error>,
     ) -> Result<(), Error> {
         let native_device = self.shared_device.native();
@@ -84,14 +83,14 @@ impl QueueShared {
 
 /// GPU execution unit to run your command buffers.
 pub struct Queue {
-    shared: Arc<QueueShared>,
+    shared: QueueShared,
 }
 
 impl Queue {
     pub fn new(device: &Device, family: u32, index: u32) -> Result<Self, Error> {
         let shared = QueueShared::new(device.shared(), family, index)?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
     pub fn build_and_submit(

--- a/src/resources/buffer.rs
+++ b/src/resources/buffer.rs
@@ -43,14 +43,14 @@ impl BufferInfo {
 }
 
 pub(crate) struct BufferShared<'a> {
-	shared_device: &'a DeviceShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     shared_allocation: &'a AllocationShared<'a>,
     device_buffer: vk::Buffer,
     buffer_info: BufferInfo,
 }
 
 impl<'a> BufferShared<'a> {
-	pub fn new(shared_allocation: &'a AllocationShared<'a>, buffer_info: &BufferInfo) -> Result<Self, Error> {
+    pub fn new(shared_allocation: &'a AllocationShared<'a>, buffer_info: &BufferInfo) -> Result<Self, Error> {
         let shared_device = shared_allocation.device();
         let native_device = shared_device.native();
 
@@ -224,25 +224,23 @@ impl<'a> Buffer<'a> {
     pub fn new(allocation: &'a Allocation<'a>, info: &BufferInfo) -> Result<Self, Error> {
         let buffer_shared = BufferShared::new(allocation.shared(), info)?;
 
-        Ok(Self {
-            shared: buffer_shared,
-        })
+        Ok(Self { shared: buffer_shared })
     }
 
-    pub fn new_video_decode(allocation: &'a Allocation<'a>, info: &BufferInfo, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+    pub fn new_video_decode(
+        allocation: &'a Allocation<'a>,
+        info: &BufferInfo,
+        stream_inspector: &H264StreamInspector,
+    ) -> Result<Self, Error> {
         let buffer_shared = BufferShared::new_video_decode(allocation.shared(), info, stream_inspector)?;
 
-        Ok(Self {
-            shared: buffer_shared,
-        })
+        Ok(Self { shared: buffer_shared })
     }
 
     pub fn external(allocation: &'a Allocation<'a>, pointer: *mut c_void, info: &BufferInfo) -> Result<Self, Error> {
         let buffer_shared = BufferShared::external(allocation.shared(), pointer, info)?;
 
-        Ok(Self {
-            shared: buffer_shared,
-        })
+        Ok(Self { shared: buffer_shared })
     }
 
     pub fn size(&self) -> u64 {

--- a/src/resources/buffer.rs
+++ b/src/resources/buffer.rs
@@ -200,7 +200,7 @@ impl<'a> BufferShared<'a> {
         self.device_buffer
     }
 
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared_device
     }
 }
@@ -248,7 +248,7 @@ impl<'a> Buffer<'a> {
     }
 
     #[allow(unused)]
-    pub(crate) fn shared(&self) -> &BufferShared {
+    pub(crate) fn shared(&self) -> &BufferShared<'_> {
         &self.shared
     }
 

--- a/src/resources/image.rs
+++ b/src/resources/image.rs
@@ -1,6 +1,3 @@
-use std::rc::Rc;
-use std::sync::Arc;
-
 use crate::allocation::{Allocation, AllocationShared, MemoryTypeIndex};
 use ash::vk::{Extent3D, Format, ImageCreateInfo, ImageLayout, ImageTiling, ImageType, ImageUsageFlags, SampleCountFlags};
 
@@ -99,13 +96,13 @@ impl ImageInfo {
 }
 
 pub(crate) struct ImageShared {
-    shared_device: Arc<DeviceShared>,
+    shared_device: DeviceShared,
     native_image: ash::vk::Image,
     info: ImageInfo,
 }
 
 impl ImageShared {
-    fn new(shared_device: Arc<DeviceShared>, info: &ImageInfo) -> Result<Self, Error> {
+    fn new(shared_device: DeviceShared, info: &ImageInfo) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let create_image = ImageCreateInfo::default()
@@ -131,7 +128,7 @@ impl ImageShared {
         }
     }
 
-    fn new_video_target(shared_device: Arc<DeviceShared>, info: &ImageInfo, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+    fn new_video_target(shared_device: DeviceShared, info: &ImageInfo, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         unsafe {
@@ -160,7 +157,7 @@ impl ImageShared {
         }
     }
 
-    fn bind(self, shared_allocation: Arc<AllocationShared>) -> Result<Self, Error> {
+    fn bind(self, shared_allocation: AllocationShared) -> Result<Self, Error> {
         let native_device = self.shared_device.native();
         let native_image = self.native_image;
         let native_allocation = shared_allocation.native();
@@ -190,7 +187,7 @@ impl ImageShared {
         self.native_image
     }
 
-    pub(crate) fn device(&self) -> Arc<DeviceShared> {
+    pub(crate) fn device(&self) -> DeviceShared {
         self.shared_device.clone()
     }
 
@@ -229,7 +226,7 @@ impl UnboundImage {
 
     pub fn bind(self, allocation: &Allocation) -> Result<Image, Error> {
         let shared = self.shared.bind(allocation.shared())?;
-        Ok(Image { shared: Rc::new(shared) })
+        Ok(Image { shared })
     }
 
     pub fn memory_requirement(&self) -> MemoryRequirements {
@@ -239,11 +236,11 @@ impl UnboundImage {
 
 /// A often 2D image, usually stored on the GPU.
 pub struct Image {
-    shared: Rc<ImageShared>,
+    shared: mageShared,
 }
 
 impl Image {
-    pub(crate) fn shared(&self) -> Rc<ImageShared> {
+    pub(crate) fn shared(&self) -> ImageShared {
         self.shared.clone()
     }
 
@@ -253,7 +250,7 @@ impl Image {
     }
 
     #[allow(unused)]
-    pub(crate) fn device(&self) -> Arc<DeviceShared> {
+    pub(crate) fn device(&self) -> DeviceShared {
         self.shared.shared_device.clone()
     }
 

--- a/src/resources/image.rs
+++ b/src/resources/image.rs
@@ -191,7 +191,7 @@ impl<'a> ImageShared<'a> {
         self.native_image
     }
 
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared_device
     }
 
@@ -244,7 +244,7 @@ pub struct Image<'a> {
 }
 
 impl<'a> Image<'a> {
-    pub(crate) fn shared(&self) -> &ImageShared {
+    pub(crate) fn shared(&self) -> &ImageShared<'_> {
         &self.shared
     }
 
@@ -254,7 +254,7 @@ impl<'a> Image<'a> {
     }
 
     #[allow(unused)]
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared.shared_device
     }
 

--- a/src/resources/image.rs
+++ b/src/resources/image.rs
@@ -96,13 +96,13 @@ impl ImageInfo {
 }
 
 pub(crate) struct ImageShared<'a> {
-	shared_device: &'a DeviceShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     native_image: ash::vk::Image,
     info: ImageInfo,
 }
 
 impl<'a> ImageShared<'a> {
-	fn new(shared_device: &'a DeviceShared<'a>, info: &ImageInfo) -> Result<Self, Error> {
+    fn new(shared_device: &'a DeviceShared<'a>, info: &ImageInfo) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let create_image = ImageCreateInfo::default()
@@ -128,7 +128,11 @@ impl<'a> ImageShared<'a> {
         }
     }
 
-    fn new_video_target(shared_device: &'a DeviceShared<'a>, info: &ImageInfo, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+    fn new_video_target(
+        shared_device: &'a DeviceShared<'a>,
+        info: &ImageInfo,
+        stream_inspector: &H264StreamInspector,
+    ) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         unsafe {

--- a/src/resources/imageview.rs
+++ b/src/resources/imageview.rs
@@ -1,6 +1,3 @@
-use std::rc::Rc;
-use std::sync::Arc;
-
 use ash::vk::{Format, ImageAspectFlags, ImageSubresourceRange, ImageViewCreateInfo, ImageViewType};
 
 use crate::device::DeviceShared;
@@ -50,13 +47,13 @@ impl ImageViewInfo {
 }
 
 pub(crate) struct ImageViewShared {
-    shared_image: Rc<ImageShared>,
-    shared_device: Arc<DeviceShared>,
+    shared_image: ImageShared,
+    shared_device: DeviceShared,
     native_view: ash::vk::ImageView,
 }
 
 impl ImageViewShared {
-    pub fn new(shared_image: Rc<ImageShared>, info: &ImageViewInfo) -> Result<Self, Error> {
+    pub fn new(shared_image: ImageShared, info: &ImageViewInfo) -> Result<Self, Error> {
         let shared_device = shared_image.device();
 
         let native_image = shared_image.native();
@@ -88,7 +85,7 @@ impl ImageViewShared {
         self.native_view
     }
 
-    pub(crate) fn image(&self) -> Rc<ImageShared> {
+    pub(crate) fn image(&self) -> ImageShared {
         self.shared_image.clone()
     }
 }
@@ -105,7 +102,7 @@ impl Drop for ImageViewShared {
 
 /// View of an [`Image`](Image).
 pub struct ImageView {
-    shared_view: Rc<ImageViewShared>,
+    shared_view: ImageViewShared,
 }
 
 impl ImageView {
@@ -113,11 +110,11 @@ impl ImageView {
         let shared_view = ImageViewShared::new(image.shared(), info)?;
 
         Ok(Self {
-            shared_view: Rc::new(shared_view),
+            shared_view: shared_view,
         })
     }
 
-    pub(crate) fn shared(&self) -> Rc<ImageViewShared> {
+    pub(crate) fn shared(&self) -> ImageViewShared {
         self.shared_view.clone()
     }
 

--- a/src/resources/imageview.rs
+++ b/src/resources/imageview.rs
@@ -85,7 +85,7 @@ impl<'a> ImageViewShared<'a> {
         self.native_view
     }
 
-    pub(crate) fn image(&self) -> &ImageShared {
+    pub(crate) fn image(&self) -> &ImageShared<'_> {
         &self.shared_image
     }
 }
@@ -112,7 +112,7 @@ impl<'a> ImageView<'a> {
         Ok(Self { shared_view: shared_view })
     }
 
-    pub(crate) fn shared(&self) -> &ImageViewShared {
+    pub(crate) fn shared(&self) -> &ImageViewShared<'_> {
         &self.shared_view
     }
 

--- a/src/resources/imageview.rs
+++ b/src/resources/imageview.rs
@@ -46,14 +46,14 @@ impl ImageViewInfo {
     }
 }
 
-pub(crate) struct ImageViewShared {
-    shared_image: ImageShared,
-    shared_device: DeviceShared,
+pub(crate) struct ImageViewShared<'a> {
+	shared_image: &'a ImageShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     native_view: ash::vk::ImageView,
 }
 
-impl ImageViewShared {
-    pub fn new(shared_image: ImageShared, info: &ImageViewInfo) -> Result<Self, Error> {
+impl<'a> ImageViewShared<'a> {
+	pub fn new(shared_image: &'a ImageShared<'a>, info: &ImageViewInfo) -> Result<Self, Error> {
         let shared_device = shared_image.device();
 
         let native_image = shared_image.native();
@@ -85,12 +85,12 @@ impl ImageViewShared {
         self.native_view
     }
 
-    pub(crate) fn image(&self) -> ImageShared {
-        self.shared_image.clone()
+    pub(crate) fn image(&self) -> &ImageShared {
+        &self.shared_image
     }
 }
 
-impl Drop for ImageViewShared {
+impl<'a> Drop for ImageViewShared<'a> {
     fn drop(&mut self) {
         let native_device = self.shared_device.native();
 
@@ -101,12 +101,12 @@ impl Drop for ImageViewShared {
 }
 
 /// View of an [`Image`](Image).
-pub struct ImageView {
-    shared_view: ImageViewShared,
+pub struct ImageView<'a> {
+    shared_view: ImageViewShared<'a>,
 }
 
-impl ImageView {
-    pub fn new(image: &Image, info: &ImageViewInfo) -> Result<Self, Error> {
+impl<'a> ImageView<'a> {
+    pub fn new(image: &'a Image<'a>, info: &ImageViewInfo) -> Result<Self, Error> {
         let shared_view = ImageViewShared::new(image.shared(), info)?;
 
         Ok(Self {
@@ -114,8 +114,8 @@ impl ImageView {
         })
     }
 
-    pub(crate) fn shared(&self) -> ImageViewShared {
-        self.shared_view.clone()
+    pub(crate) fn shared(&self) -> &ImageViewShared {
+        &self.shared_view
     }
 
     pub(crate) fn native(&self) -> ash::vk::ImageView {

--- a/src/resources/imageview.rs
+++ b/src/resources/imageview.rs
@@ -47,13 +47,13 @@ impl ImageViewInfo {
 }
 
 pub(crate) struct ImageViewShared<'a> {
-	shared_image: &'a ImageShared<'a>,
+    shared_image: &'a ImageShared<'a>,
     shared_device: &'a DeviceShared<'a>,
     native_view: ash::vk::ImageView,
 }
 
 impl<'a> ImageViewShared<'a> {
-	pub fn new(shared_image: &'a ImageShared<'a>, info: &ImageViewInfo) -> Result<Self, Error> {
+    pub fn new(shared_image: &'a ImageShared<'a>, info: &ImageViewInfo) -> Result<Self, Error> {
         let shared_device = shared_image.device();
 
         let native_image = shared_image.native();
@@ -109,9 +109,7 @@ impl<'a> ImageView<'a> {
     pub fn new(image: &'a Image<'a>, info: &ImageViewInfo) -> Result<Self, Error> {
         let shared_view = ImageViewShared::new(image.shared(), info)?;
 
-        Ok(Self {
-            shared_view: shared_view,
-        })
+        Ok(Self { shared_view: shared_view })
     }
 
     pub(crate) fn shared(&self) -> &ImageViewShared {

--- a/src/shader/parameters.rs
+++ b/src/shader/parameters.rs
@@ -155,7 +155,7 @@ impl<'a, T: ShaderParameterSet> Parameters<'a, T> {
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> &ParametersShared<T> {
+    pub(crate) fn shared(&self) -> &ParametersShared<'_, T> {
         &self.shared
     }
 }

--- a/src/shader/parameters.rs
+++ b/src/shader/parameters.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use ash::vk::{DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo, DescriptorType, ShaderStageFlags};
 
@@ -94,13 +93,13 @@ where
 }
 
 pub(crate) struct ParametersShared<T> {
-    shared_device: Arc<DeviceShared>,
+    shared_device: DeviceShared,
     descriptor_set_layout: DescriptorSetLayout,
     _phantom: PhantomData<T>,
 }
 
 impl<T: ShaderParameterSet> ParametersShared<T> {
-    pub fn new(shared_device: Arc<DeviceShared>) -> Result<Self, Error> {
+    pub fn new(shared_device: DeviceShared) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
         let descriptor_types = T::descriptor_types();
@@ -146,17 +145,17 @@ impl<T> Drop for ParametersShared<T> {
 
 /// Holds parameter information for a [Shader](crate::shader::Shader).
 pub struct Parameters<T: ShaderParameterSet> {
-    shared: Arc<ParametersShared<T>>,
+    shared: ParametersShared<T>,
 }
 
 impl<T: ShaderParameterSet> Parameters<T> {
     pub fn new(device: &Device) -> Result<Self, Error> {
         let shared = ParametersShared::new(device.shared())?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> Arc<ParametersShared<T>> {
+    pub(crate) fn shared(&self) -> ParametersShared<T> {
         self.shared.clone()
     }
 }

--- a/src/shader/parameters.rs
+++ b/src/shader/parameters.rs
@@ -92,13 +92,13 @@ where
     }
 }
 
-pub(crate) struct ParametersShared<'a,T> {
-	shared_device: &'a DeviceShared<'a>,
+pub(crate) struct ParametersShared<'a, T> {
+    shared_device: &'a DeviceShared<'a>,
     descriptor_set_layout: DescriptorSetLayout,
     _phantom: PhantomData<T>,
 }
 
-impl<'a,T: ShaderParameterSet> ParametersShared<'a,T> {
+impl<'a, T: ShaderParameterSet> ParametersShared<'a, T> {
     pub fn new(shared_device: &'a DeviceShared<'a>) -> Result<Self, Error> {
         let native_device = shared_device.native();
 
@@ -133,7 +133,7 @@ impl<'a,T: ShaderParameterSet> ParametersShared<'a,T> {
     }
 }
 
-impl<'a,T> Drop for ParametersShared<'a,T> {
+impl<'a, T> Drop for ParametersShared<'a, T> {
     fn drop(&mut self) {
         unsafe {
             self.shared_device
@@ -144,11 +144,11 @@ impl<'a,T> Drop for ParametersShared<'a,T> {
 }
 
 /// Holds parameter information for a [Shader](crate::shader::Shader).
-pub struct Parameters<'a,T: ShaderParameterSet> {
-    shared: ParametersShared<'a,T>,
+pub struct Parameters<'a, T: ShaderParameterSet> {
+    shared: ParametersShared<'a, T>,
 }
 
-impl<'a,T: ShaderParameterSet> Parameters<'a,T> {
+impl<'a, T: ShaderParameterSet> Parameters<'a, T> {
     pub fn new(device: &'a Device) -> Result<Self, Error> {
         let shared = ParametersShared::new(device.shared())?;
 

--- a/src/shader/pipeline.rs
+++ b/src/shader/pipeline.rs
@@ -9,16 +9,16 @@ use ash::vk::{
 };
 
 #[expect(unused)]
-pub(crate) struct PipelineShared<T> {
-    shared_device: DeviceShared,
-    shared_shader: ShaderShared<T>,
-    shared_parameters: ParametersShared<T>,
+pub(crate) struct PipelineShared<'a,T> {
+    shared_device: &'a DeviceShared<'a>,
+    shared_shader: &'a ShaderShared<'a,T>,
+    shared_parameters: &'a ParametersShared<'a,T>,
     native_layout: PipelineLayout,
     native_pipeline: ash::vk::Pipeline,
 }
 
-impl<T: ShaderParameterSet> PipelineShared<T> {
-    pub(crate) fn new(shared_device: DeviceShared, shared_shader: ShaderShared<T>) -> Result<Self, Error> {
+impl<'a,T: ShaderParameterSet> PipelineShared<'a,T> {
+    pub(crate) fn new(shared_device: &'a DeviceShared<'a>, shared_shader: &'a ShaderShared<T>) -> Result<Self, Error> {
         let native_device = shared_device.native();
         let shared_parameters = shared_shader.parameters();
 
@@ -65,12 +65,12 @@ impl<T: ShaderParameterSet> PipelineShared<T> {
         }
     }
 
-    pub(crate) fn parameters(&self) -> ParametersShared<T> {
-        self.shared_parameters.clone()
+    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
+        &self.shared_parameters
     }
 }
 
-impl<T> PipelineShared<T> {
+impl<'a,T> PipelineShared<'a,T> {
     pub(crate) fn native(&self) -> ash::vk::Pipeline {
         self.native_pipeline
     }
@@ -79,12 +79,12 @@ impl<T> PipelineShared<T> {
         self.native_layout
     }
 
-    pub(crate) fn device(&self) -> DeviceShared {
-        self.shared_device.clone()
+    pub(crate) fn device(&self) -> &DeviceShared {
+        &self.shared_device
     }
 }
 
-impl<T> Drop for PipelineShared<T> {
+impl<'a,T> Drop for PipelineShared<'a,T> {
     fn drop(&mut self) {
         let native_device = self.shared_device.native();
 
@@ -97,20 +97,20 @@ impl<T> Drop for PipelineShared<T> {
 
 /// Configuration how exactly a [Shader](Shader) should be invoked.
 #[allow(unused)]
-pub struct Pipeline<T: ShaderParameterSet> {
-    shared: PipelineShared<T>,
+pub struct Pipeline<'a,T: ShaderParameterSet> {
+    shared: PipelineShared<'a,T>,
 }
 
-impl<T: ShaderParameterSet> Pipeline<T> {
-    pub fn new(device: &Device, shader: &Shader<T>) -> Result<Self, Error> {
+impl<'a,T: ShaderParameterSet> Pipeline<'a,T> {
+    pub fn new(device: &'a Device, shader: &'a Shader<T>) -> Result<Self, Error> {
         let shared = PipelineShared::new(device.shared(), shader.shared())?;
 
         Ok(Self { shared })
     }
 
     #[allow(unused)]
-    pub(crate) fn shared(&self) -> PipelineShared<T> {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &PipelineShared<T> {
+        &self.shared
     }
 
     #[allow(unused)]

--- a/src/shader/pipeline.rs
+++ b/src/shader/pipeline.rs
@@ -7,19 +7,18 @@ use crate::shader::ShaderParameterSet;
 use ash::vk::{
     ComputePipelineCreateInfo, PipelineCache, PipelineLayout, PipelineLayoutCreateInfo, PipelineShaderStageCreateInfo, ShaderStageFlags,
 };
-use std::sync::Arc;
 
 #[expect(unused)]
 pub(crate) struct PipelineShared<T> {
-    shared_device: Arc<DeviceShared>,
-    shared_shader: Arc<ShaderShared<T>>,
-    shared_parameters: Arc<ParametersShared<T>>,
+    shared_device: DeviceShared,
+    shared_shader: ShaderShared<T>,
+    shared_parameters: ParametersShared<T>,
     native_layout: PipelineLayout,
     native_pipeline: ash::vk::Pipeline,
 }
 
 impl<T: ShaderParameterSet> PipelineShared<T> {
-    pub(crate) fn new(shared_device: Arc<DeviceShared>, shared_shader: Arc<ShaderShared<T>>) -> Result<Self, Error> {
+    pub(crate) fn new(shared_device: DeviceShared, shared_shader: ShaderShared<T>) -> Result<Self, Error> {
         let native_device = shared_device.native();
         let shared_parameters = shared_shader.parameters();
 
@@ -66,7 +65,7 @@ impl<T: ShaderParameterSet> PipelineShared<T> {
         }
     }
 
-    pub(crate) fn parameters(&self) -> Arc<ParametersShared<T>> {
+    pub(crate) fn parameters(&self) -> ParametersShared<T> {
         self.shared_parameters.clone()
     }
 }
@@ -80,7 +79,7 @@ impl<T> PipelineShared<T> {
         self.native_layout
     }
 
-    pub(crate) fn device(&self) -> Arc<DeviceShared> {
+    pub(crate) fn device(&self) -> DeviceShared {
         self.shared_device.clone()
     }
 }
@@ -99,18 +98,18 @@ impl<T> Drop for PipelineShared<T> {
 /// Configuration how exactly a [Shader](Shader) should be invoked.
 #[allow(unused)]
 pub struct Pipeline<T: ShaderParameterSet> {
-    shared: Arc<PipelineShared<T>>,
+    shared: PipelineShared<T>,
 }
 
 impl<T: ShaderParameterSet> Pipeline<T> {
     pub fn new(device: &Device, shader: &Shader<T>) -> Result<Self, Error> {
         let shared = PipelineShared::new(device.shared(), shader.shared())?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
     #[allow(unused)]
-    pub(crate) fn shared(&self) -> Arc<PipelineShared<T>> {
+    pub(crate) fn shared(&self) -> PipelineShared<T> {
         self.shared.clone()
     }
 

--- a/src/shader/pipeline.rs
+++ b/src/shader/pipeline.rs
@@ -65,7 +65,7 @@ impl<'a, T: ShaderParameterSet> PipelineShared<'a, T> {
         }
     }
 
-    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
+    pub(crate) fn parameters(&self) -> &ParametersShared<'_, T> {
         &self.shared_parameters
     }
 }
@@ -79,7 +79,7 @@ impl<'a, T> PipelineShared<'a, T> {
         self.native_layout
     }
 
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared_device
     }
 }
@@ -109,7 +109,7 @@ impl<'a, T: ShaderParameterSet> Pipeline<'a, T> {
     }
 
     #[allow(unused)]
-    pub(crate) fn shared(&self) -> &PipelineShared<T> {
+    pub(crate) fn shared(&self) -> &PipelineShared<'_, T> {
         &self.shared
     }
 

--- a/src/shader/pipeline.rs
+++ b/src/shader/pipeline.rs
@@ -9,15 +9,15 @@ use ash::vk::{
 };
 
 #[expect(unused)]
-pub(crate) struct PipelineShared<'a,T> {
+pub(crate) struct PipelineShared<'a, T> {
     shared_device: &'a DeviceShared<'a>,
-    shared_shader: &'a ShaderShared<'a,T>,
-    shared_parameters: &'a ParametersShared<'a,T>,
+    shared_shader: &'a ShaderShared<'a, T>,
+    shared_parameters: &'a ParametersShared<'a, T>,
     native_layout: PipelineLayout,
     native_pipeline: ash::vk::Pipeline,
 }
 
-impl<'a,T: ShaderParameterSet> PipelineShared<'a,T> {
+impl<'a, T: ShaderParameterSet> PipelineShared<'a, T> {
     pub(crate) fn new(shared_device: &'a DeviceShared<'a>, shared_shader: &'a ShaderShared<T>) -> Result<Self, Error> {
         let native_device = shared_device.native();
         let shared_parameters = shared_shader.parameters();
@@ -70,7 +70,7 @@ impl<'a,T: ShaderParameterSet> PipelineShared<'a,T> {
     }
 }
 
-impl<'a,T> PipelineShared<'a,T> {
+impl<'a, T> PipelineShared<'a, T> {
     pub(crate) fn native(&self) -> ash::vk::Pipeline {
         self.native_pipeline
     }
@@ -84,7 +84,7 @@ impl<'a,T> PipelineShared<'a,T> {
     }
 }
 
-impl<'a,T> Drop for PipelineShared<'a,T> {
+impl<'a, T> Drop for PipelineShared<'a, T> {
     fn drop(&mut self) {
         let native_device = self.shared_device.native();
 
@@ -97,11 +97,11 @@ impl<'a,T> Drop for PipelineShared<'a,T> {
 
 /// Configuration how exactly a [Shader](Shader) should be invoked.
 #[allow(unused)]
-pub struct Pipeline<'a,T: ShaderParameterSet> {
-    shared: PipelineShared<'a,T>,
+pub struct Pipeline<'a, T: ShaderParameterSet> {
+    shared: PipelineShared<'a, T>,
 }
 
-impl<'a,T: ShaderParameterSet> Pipeline<'a,T> {
+impl<'a, T: ShaderParameterSet> Pipeline<'a, T> {
     pub fn new(device: &'a Device, shader: &'a Shader<T>) -> Result<Self, Error> {
         let shared = PipelineShared::new(device.shared(), shader.shared())?;
 

--- a/src/shader/shader.rs
+++ b/src/shader/shader.rs
@@ -4,21 +4,20 @@ use crate::shader::parameters::{Parameters, ParametersShared};
 use crate::shader::ShaderParameterSet;
 use ash::vk::{ShaderModule, ShaderModuleCreateInfo};
 use std::ffi::{CStr, CString};
-use std::sync::Arc;
 
 pub(crate) struct ShaderShared<T> {
-    shared_device: Arc<DeviceShared>,
-    shared_parameters: Arc<ParametersShared<T>>,
+    shared_device: DeviceShared,
+    shared_parameters: ParametersShared<T>,
     shader_module: ShaderModule,
     entry_point: CString,
 }
 
 impl<T: ShaderParameterSet> ShaderShared<T> {
     pub fn new(
-        shared_device: Arc<DeviceShared>,
+        shared_device: DeviceShared,
         spirv_code: &[u8],
         entry_point: &str,
-        shared_parameters: Arc<ParametersShared<T>>,
+        shared_parameters: ParametersShared<T>,
     ) -> Result<Self, Error> {
         let entry_point = CString::new(entry_point)?;
 
@@ -46,7 +45,7 @@ impl<T: ShaderParameterSet> ShaderShared<T> {
         &self.entry_point
     }
 
-    pub(crate) fn parameters(&self) -> Arc<ParametersShared<T>> {
+    pub(crate) fn parameters(&self) -> ParametersShared<T> {
         self.shared_parameters.clone()
     }
 }
@@ -61,17 +60,17 @@ impl<T> Drop for ShaderShared<T> {
 
 /// Some GPU program, mostly for postprocessing video frames.
 pub struct Shader<T: ShaderParameterSet> {
-    shared: Arc<ShaderShared<T>>,
+    shared: ShaderShared<T>,
 }
 
 impl<T: ShaderParameterSet> Shader<T> {
     pub fn new(device: &Device, spirv_code: &[u8], entry_point: &str, parameters: &Parameters<T>) -> Result<Self, Error> {
         let shared = ShaderShared::<T>::new(device.shared(), spirv_code, entry_point, parameters.shared())?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> Arc<ShaderShared<T>> {
+    pub(crate) fn shared(&self) -> ShaderShared<T> {
         self.shared.clone()
     }
 
@@ -81,7 +80,7 @@ impl<T: ShaderParameterSet> Shader<T> {
     }
 
     #[allow(unused)]
-    pub(crate) fn parameters(&self) -> Arc<ParametersShared<T>> {
+    pub(crate) fn parameters(&self) -> ParametersShared<T> {
         self.shared().parameters()
     }
 }

--- a/src/shader/shader.rs
+++ b/src/shader/shader.rs
@@ -45,7 +45,7 @@ impl<'a, T: ShaderParameterSet> ShaderShared<'a, T> {
         &self.entry_point
     }
 
-    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
+    pub(crate) fn parameters(&self) -> &ParametersShared<'_, T> {
         &self.shared_parameters
     }
 }
@@ -70,7 +70,7 @@ impl<'a, T: ShaderParameterSet> Shader<'a, T> {
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> &ShaderShared<T> {
+    pub(crate) fn shared(&self) -> &ShaderShared<'_, T> {
         &self.shared
     }
 
@@ -80,7 +80,7 @@ impl<'a, T: ShaderParameterSet> Shader<'a, T> {
     }
 
     #[allow(unused)]
-    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
+    pub(crate) fn parameters(&self) -> &ParametersShared<'_, T> {
         self.shared().parameters()
     }
 }

--- a/src/shader/shader.rs
+++ b/src/shader/shader.rs
@@ -5,19 +5,19 @@ use crate::shader::ShaderParameterSet;
 use ash::vk::{ShaderModule, ShaderModuleCreateInfo};
 use std::ffi::{CStr, CString};
 
-pub(crate) struct ShaderShared<'a,T> {
+pub(crate) struct ShaderShared<'a, T> {
     shared_device: &'a DeviceShared<'a>,
-    shared_parameters: &'a ParametersShared<'a,T>,
+    shared_parameters: &'a ParametersShared<'a, T>,
     shader_module: ShaderModule,
     entry_point: CString,
 }
 
-impl<'a,T: ShaderParameterSet> ShaderShared<'a,T> {
+impl<'a, T: ShaderParameterSet> ShaderShared<'a, T> {
     pub fn new(
         shared_device: &'a DeviceShared<'a>,
         spirv_code: &[u8],
         entry_point: &str,
-        shared_parameters: &'a ParametersShared<'a,T>,
+        shared_parameters: &'a ParametersShared<'a, T>,
     ) -> Result<Self, Error> {
         let entry_point = CString::new(entry_point)?;
 
@@ -50,7 +50,7 @@ impl<'a,T: ShaderParameterSet> ShaderShared<'a,T> {
     }
 }
 
-impl<'a,T> Drop for ShaderShared<'a,T> {
+impl<'a, T> Drop for ShaderShared<'a, T> {
     fn drop(&mut self) {
         unsafe {
             self.shared_device.native().destroy_shader_module(self.shader_module, None);
@@ -59,11 +59,11 @@ impl<'a,T> Drop for ShaderShared<'a,T> {
 }
 
 /// Some GPU program, mostly for postprocessing video frames.
-pub struct Shader<'a,T: ShaderParameterSet> {
-    shared: ShaderShared<'a,T>,
+pub struct Shader<'a, T: ShaderParameterSet> {
+    shared: ShaderShared<'a, T>,
 }
 
-impl<'a,T: ShaderParameterSet> Shader<'a,T> {
+impl<'a, T: ShaderParameterSet> Shader<'a, T> {
     pub fn new(device: &'a Device, spirv_code: &[u8], entry_point: &str, parameters: &'a Parameters<T>) -> Result<Self, Error> {
         let shared = ShaderShared::<T>::new(device.shared(), spirv_code, entry_point, parameters.shared())?;
 

--- a/src/shader/shader.rs
+++ b/src/shader/shader.rs
@@ -5,19 +5,19 @@ use crate::shader::ShaderParameterSet;
 use ash::vk::{ShaderModule, ShaderModuleCreateInfo};
 use std::ffi::{CStr, CString};
 
-pub(crate) struct ShaderShared<T> {
-    shared_device: DeviceShared,
-    shared_parameters: ParametersShared<T>,
+pub(crate) struct ShaderShared<'a,T> {
+    shared_device: &'a DeviceShared<'a>,
+    shared_parameters: &'a ParametersShared<'a,T>,
     shader_module: ShaderModule,
     entry_point: CString,
 }
 
-impl<T: ShaderParameterSet> ShaderShared<T> {
+impl<'a,T: ShaderParameterSet> ShaderShared<'a,T> {
     pub fn new(
-        shared_device: DeviceShared,
+        shared_device: &'a DeviceShared<'a>,
         spirv_code: &[u8],
         entry_point: &str,
-        shared_parameters: ParametersShared<T>,
+        shared_parameters: &'a ParametersShared<'a,T>,
     ) -> Result<Self, Error> {
         let entry_point = CString::new(entry_point)?;
 
@@ -45,12 +45,12 @@ impl<T: ShaderParameterSet> ShaderShared<T> {
         &self.entry_point
     }
 
-    pub(crate) fn parameters(&self) -> ParametersShared<T> {
-        self.shared_parameters.clone()
+    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
+        &self.shared_parameters
     }
 }
 
-impl<T> Drop for ShaderShared<T> {
+impl<'a,T> Drop for ShaderShared<'a,T> {
     fn drop(&mut self) {
         unsafe {
             self.shared_device.native().destroy_shader_module(self.shader_module, None);
@@ -59,19 +59,19 @@ impl<T> Drop for ShaderShared<T> {
 }
 
 /// Some GPU program, mostly for postprocessing video frames.
-pub struct Shader<T: ShaderParameterSet> {
-    shared: ShaderShared<T>,
+pub struct Shader<'a,T: ShaderParameterSet> {
+    shared: ShaderShared<'a,T>,
 }
 
-impl<T: ShaderParameterSet> Shader<T> {
-    pub fn new(device: &Device, spirv_code: &[u8], entry_point: &str, parameters: &Parameters<T>) -> Result<Self, Error> {
+impl<'a,T: ShaderParameterSet> Shader<'a,T> {
+    pub fn new(device: &'a Device, spirv_code: &[u8], entry_point: &str, parameters: &'a Parameters<T>) -> Result<Self, Error> {
         let shared = ShaderShared::<T>::new(device.shared(), spirv_code, entry_point, parameters.shared())?;
 
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> ShaderShared<T> {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &ShaderShared<T> {
+        &self.shared
     }
 
     #[allow(unused)]
@@ -80,7 +80,7 @@ impl<T: ShaderParameterSet> Shader<T> {
     }
 
     #[allow(unused)]
-    pub(crate) fn parameters(&self) -> ParametersShared<T> {
+    pub(crate) fn parameters(&self) -> &ParametersShared<T> {
         self.shared().parameters()
     }
 }

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -31,8 +31,8 @@ impl VideoDecodeCapabilities {
     }
 }
 
-pub(crate) struct VideoSessionShared {
-    shared_device: DeviceShared,
+pub(crate) struct VideoSessionShared<'a> {
+	shared_device: &'a DeviceShared<'a>,
     native_queue_fns: KhrVideoQueueDeviceFn,
     native_decode_queue_fns: KhrVideoDecodeQueueDeviceFn,
     // native_video_instance_fns: KhrVideoQueueInstanceFn,
@@ -41,8 +41,8 @@ pub(crate) struct VideoSessionShared {
     decode_capabilities: VideoDecodeCapabilities,
 }
 
-impl VideoSessionShared {
-    pub fn new(device: &Device, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+impl<'a> VideoSessionShared<'a> {
+    pub fn new(device: &'a Device, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let shared_device = device.shared();
         let shared_instance = shared_device.instance();
 
@@ -222,8 +222,8 @@ impl VideoSessionShared {
     //     self.native_video_instance_fns.clone()
     // }
 
-    pub(crate) fn device(&self) -> DeviceShared {
-        self.shared_device.clone()
+    pub(crate) fn device(&self) -> &DeviceShared {
+        &self.shared_device
     }
 
     pub(crate) fn decode_capabilities(&self) -> &VideoDecodeCapabilities {
@@ -231,7 +231,7 @@ impl VideoSessionShared {
     }
 }
 
-impl Drop for VideoSessionShared {
+impl<'a> Drop for VideoSessionShared<'a> {
     fn drop(&mut self) {
         let native_device = self.shared_device.native();
         let destroy_video_session_khr = self.native_queue_fns.destroy_video_session_khr;
@@ -243,19 +243,19 @@ impl Drop for VideoSessionShared {
 }
 
 /// Vulkan-internal state needed for video ops.
-pub struct VideoSession {
-    shared: VideoSessionShared,
+pub struct VideoSession<'a> {
+    shared: VideoSessionShared<'a>,
 }
 
-impl VideoSession {
-    pub fn new(device: &Device, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+impl<'a> VideoSession<'a> {
+    pub fn new(device: &'a Device, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let shared = VideoSessionShared::new(device, stream_inspector)?;
 
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> VideoSessionShared {
-        self.shared.clone()
+    pub(crate) fn shared(&self) -> &VideoSessionShared {
+        &self.shared
     }
 }
 

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -32,7 +32,7 @@ impl VideoDecodeCapabilities {
 }
 
 pub(crate) struct VideoSessionShared<'a> {
-	shared_device: &'a DeviceShared<'a>,
+    shared_device: &'a DeviceShared<'a>,
     native_queue_fns: KhrVideoQueueDeviceFn,
     native_decode_queue_fns: KhrVideoDecodeQueueDeviceFn,
     // native_video_instance_fns: KhrVideoQueueInstanceFn,

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -16,7 +16,6 @@ use ash::vk::{
     VideoSessionCreateInfoKHR, VideoSessionKHR, VideoSessionMemoryRequirementsKHR,
 };
 use std::ptr::{null, null_mut};
-use std::sync::Arc;
 
 pub(crate) struct VideoDecodeCapabilities {
     flags: VideoDecodeCapabilityFlagsKHR,
@@ -33,7 +32,7 @@ impl VideoDecodeCapabilities {
 }
 
 pub(crate) struct VideoSessionShared {
-    shared_device: Arc<DeviceShared>,
+    shared_device: DeviceShared,
     native_queue_fns: KhrVideoQueueDeviceFn,
     native_decode_queue_fns: KhrVideoDecodeQueueDeviceFn,
     // native_video_instance_fns: KhrVideoQueueInstanceFn,
@@ -223,7 +222,7 @@ impl VideoSessionShared {
     //     self.native_video_instance_fns.clone()
     // }
 
-    pub(crate) fn device(&self) -> Arc<DeviceShared> {
+    pub(crate) fn device(&self) -> DeviceShared {
         self.shared_device.clone()
     }
 
@@ -245,17 +244,17 @@ impl Drop for VideoSessionShared {
 
 /// Vulkan-internal state needed for video ops.
 pub struct VideoSession {
-    shared: Arc<VideoSessionShared>,
+    shared: VideoSessionShared,
 }
 
 impl VideoSession {
     pub fn new(device: &Device, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let shared = VideoSessionShared::new(device, stream_inspector)?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> Arc<VideoSessionShared> {
+    pub(crate) fn shared(&self) -> VideoSessionShared {
         self.shared.clone()
     }
 }

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -222,7 +222,7 @@ impl<'a> VideoSessionShared<'a> {
     //     self.native_video_instance_fns.clone()
     // }
 
-    pub(crate) fn device(&self) -> &DeviceShared {
+    pub(crate) fn device(&self) -> &DeviceShared<'_> {
         &self.shared_device
     }
 
@@ -254,7 +254,7 @@ impl<'a> VideoSession<'a> {
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> &VideoSessionShared {
+    pub(crate) fn shared(&self) -> &VideoSessionShared<'_> {
         &self.shared
     }
 }

--- a/src/video/sessionparameters.rs
+++ b/src/video/sessionparameters.rs
@@ -10,15 +10,14 @@ use ash::vk::{
     VideoSessionParametersKHR, VideoSessionParametersUpdateInfoKHR,
 };
 use std::ptr::{addr_of, addr_of_mut, null};
-use std::sync::Arc;
 
 pub(crate) struct VideoSessionParametersShared {
-    shared_session: Arc<VideoSessionShared>,
+    shared_session: VideoSessionShared,
     native_parameters: VideoSessionParametersKHR,
 }
 
 impl VideoSessionParametersShared {
-    pub fn new(shared_session: Arc<VideoSessionShared>, _stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+    pub fn new(shared_session: VideoSessionShared, _stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let native_session = shared_session.native();
         let native_device = shared_session.device().native();
         let native_queue_fns = shared_session.queue_fns();
@@ -163,7 +162,7 @@ impl VideoSessionParametersShared {
         self.native_parameters
     }
 
-    pub(crate) fn video_session(&self) -> Arc<VideoSessionShared> {
+    pub(crate) fn video_session(&self) -> VideoSessionShared {
         self.shared_session.clone()
     }
 }
@@ -183,17 +182,17 @@ impl Drop for VideoSessionParametersShared {
 
 /// Vulkan-internal state needed for operating on a single video frame.
 pub struct VideoSessionParameters {
-    shared: Arc<VideoSessionParametersShared>,
+    shared: VideoSessionParametersShared,
 }
 
 impl VideoSessionParameters {
     pub fn new(session: &VideoSession, stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let shared = VideoSessionParametersShared::new(session.shared(), stream_inspector)?;
 
-        Ok(Self { shared: Arc::new(shared) })
+        Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> Arc<VideoSessionParametersShared> {
+    pub(crate) fn shared(&self) -> VideoSessionParametersShared {
         self.shared.clone()
     }
 }

--- a/src/video/sessionparameters.rs
+++ b/src/video/sessionparameters.rs
@@ -12,12 +12,12 @@ use ash::vk::{
 use std::ptr::{addr_of, addr_of_mut, null};
 
 pub(crate) struct VideoSessionParametersShared<'a> {
-	shared_session: &'a VideoSessionShared<'a>,
+    shared_session: &'a VideoSessionShared<'a>,
     native_parameters: VideoSessionParametersKHR,
 }
 
 impl<'a> VideoSessionParametersShared<'a> {
-	pub fn new(shared_session: &'a VideoSessionShared<'a>, _stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
+    pub fn new(shared_session: &'a VideoSessionShared<'a>, _stream_inspector: &H264StreamInspector) -> Result<Self, Error> {
         let native_session = shared_session.native();
         let shared_device = shared_session.device();
         let native_device = shared_device.native();

--- a/src/video/sessionparameters.rs
+++ b/src/video/sessionparameters.rs
@@ -163,7 +163,7 @@ impl<'a> VideoSessionParametersShared<'a> {
         self.native_parameters
     }
 
-    pub(crate) fn video_session(&self) -> &VideoSessionShared {
+    pub(crate) fn video_session(&self) -> &VideoSessionShared<'_> {
         &self.shared_session
     }
 }
@@ -193,7 +193,7 @@ impl<'a> VideoSessionParameters<'a> {
         Ok(Self { shared })
     }
 
-    pub(crate) fn shared(&self) -> &VideoSessionParametersShared {
+    pub(crate) fn shared(&self) -> &VideoSessionParametersShared<'_> {
         &self.shared
     }
 }


### PR DESCRIPTION
Why is there Arc everywhere? Delete all the Arc<> Rc<> RefCell<> curmudgeon and use references.  Gain the power of the borrow checker.  This is a shallow rewrite, further implications of removing Arc are not included.  Probably best to merge squashed.