### PR TITLE
Unbundle VideoProfileInfoBundle

### DIFF
--- a/src/resources/buffer.rs
+++ b/src/resources/buffer.rs
@@ -5,7 +5,7 @@ use crate::video::h264::H264StreamInspector;
 use ash::vk;
 use ash::vk::{
     BufferCreateInfo, BufferUsageFlags, DeviceSize, ExternalMemoryBufferCreateInfo, ExternalMemoryHandleTypeFlags, MappedMemoryRange,
-    MemoryMapFlags, WHOLE_SIZE,
+    MemoryMapFlags, VideoProfileListInfoKHR, WHOLE_SIZE,
 };
 use std::ffi::c_void;
 use std::sync::Arc;
@@ -96,7 +96,7 @@ impl BufferShared {
 
         let mut h264_profile_info = stream_inspector.h264_profile_info();
         let profiles = &[stream_inspector.profile_info(&mut h264_profile_info)];
-        let mut profile_list_info = stream_inspector.profile_list_info(profiles);
+        let mut profile_list_info = VideoProfileListInfoKHR::default().profiles(profiles);
 
         let buffer_create_info = BufferCreateInfo::default()
             .size(buffer_info.size)

--- a/src/resources/image.rs
+++ b/src/resources/image.rs
@@ -2,7 +2,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::allocation::{Allocation, AllocationShared, MemoryTypeIndex};
-use ash::vk::{Extent3D, Format, ImageCreateInfo, ImageLayout, ImageTiling, ImageType, ImageUsageFlags, SampleCountFlags};
+use ash::vk::{
+    Extent3D, Format, ImageCreateInfo, ImageLayout, ImageTiling, ImageType, ImageUsageFlags, SampleCountFlags, VideoProfileListInfoKHR,
+};
 
 use crate::device::{Device, DeviceShared};
 use crate::error::Error;
@@ -136,7 +138,7 @@ impl ImageShared {
 
         let mut h264_profile_info = stream_inspector.h264_profile_info();
         let profiles = &[stream_inspector.profile_info(&mut h264_profile_info)];
-        let mut profile_list_info = stream_inspector.profile_list_info(profiles);
+        let mut profile_list_info = VideoProfileListInfoKHR::default().profiles(profiles);
 
         let create_image = ImageCreateInfo::default()
             .format(info.format) // we got this from the videosession struct which listed this as teh format.

--- a/src/video/h264/h264inspector.rs
+++ b/src/video/h264/h264inspector.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use ash::vk::{
     VideoChromaSubsamplingFlagsKHR, VideoCodecOperationFlagsKHR, VideoComponentBitDepthFlagsKHR, VideoDecodeH264PictureLayoutFlagsKHR,
-    VideoDecodeH264ProfileInfoKHR, VideoProfileInfoKHR, VideoProfileListInfoKHR,
+    VideoDecodeH264ProfileInfoKHR, VideoProfileInfoKHR,
 };
 use h264_reader::annexb::AnnexBReader;
 use h264_reader::nal::pps::{PicParameterSet, PpsError};
@@ -67,9 +67,6 @@ impl H264StreamInspector {
             .luma_bit_depth(VideoComponentBitDepthFlagsKHR::TYPE_8)
             .chroma_bit_depth(VideoComponentBitDepthFlagsKHR::TYPE_8)
     }
-    pub fn profile_list_info<'a>(&self, profiles: &'a [VideoProfileInfoKHR<'_>]) -> VideoProfileListInfoKHR<'a> {
-        VideoProfileListInfoKHR::default().profiles(profiles)
-    }
 }
 
 #[cfg(test)]
@@ -77,14 +74,14 @@ mod test {
     use crate::error::Error;
     use crate::video::h264::H264StreamInspector;
     use crate::video::nal_units;
-    use ash::vk::VideoCodecOperationFlagsKHR;
+    use ash::vk::{VideoCodecOperationFlagsKHR, VideoProfileListInfoKHR};
 
     #[test]
     fn get_profile_info_list() -> Result<(), Error> {
         let inspector = H264StreamInspector::new();
         let mut h264_profile_info = inspector.h264_profile_info();
         let profiles = &[inspector.profile_info(&mut h264_profile_info)];
-        let infos = inspector.profile_list_info(profiles);
+        let infos = VideoProfileListInfoKHR::default().profiles(profiles);
 
         unsafe {
             assert_eq!(infos.profile_count, 1);

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -58,7 +58,8 @@ impl VideoSessionShared {
             .spec_version(extension_version)
             .extension_name(extension_name)?;
 
-        let profiles = stream_inspector.profiles();
+        let mut h264_profile_info = stream_inspector.h264_profile_info();
+        let profile_info = stream_inspector.profile_info(&mut h264_profile_info);
 
         let queue_family_index = shared_device
             .physical_device()
@@ -69,7 +70,7 @@ impl VideoSessionShared {
         let video_session_create_info = VideoSessionCreateInfoKHR::default()
             .queue_family_index(queue_family_index)
             .flags(VideoSessionCreateFlagsKHR::empty())
-            .video_profile(&profiles.info)
+            .video_profile(&profile_info)
             .picture_format(Format::G8_B8R8_2PLANE_420_UNORM)
             .max_coded_extent(Extent2D { width: 512, height: 512 })
             .reference_picture_format(Format::G8_B8R8_2PLANE_420_UNORM)


### PR DESCRIPTION
Avoid needing to do box pin heap tricks.  Also shrink-wraps some unsafe code to a smaller scope.