### PR TITLE
Configure VideoSession With 0 DPB Slots

### DIFF
--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -167,7 +167,7 @@ impl AddToCommandBuffer for DecodeH264 {
             .dst_stage_mask(PipelineStageFlags2::VIDEO_DECODE_KHR)
             .dst_access_mask(AccessFlags2::VIDEO_DECODE_WRITE_KHR)
             .dst_queue_family_index(QUEUE_FAMILY_IGNORED)
-            .new_layout(ImageLayout::VIDEO_DECODE_DPB_KHR)
+            .new_layout(ImageLayout::VIDEO_DECODE_DST_KHR)
             .image(native_image_dst)
             .subresource_range(ssr);
 
@@ -175,7 +175,7 @@ impl AddToCommandBuffer for DecodeH264 {
             .src_stage_mask(PipelineStageFlags2::VIDEO_DECODE_KHR)
             .src_access_mask(AccessFlags2::VIDEO_DECODE_WRITE_KHR)
             .src_queue_family_index(QUEUE_FAMILY_IGNORED)
-            .old_layout(ImageLayout::VIDEO_DECODE_DPB_KHR)
+            .old_layout(ImageLayout::VIDEO_DECODE_DST_KHR)
             .dst_stage_mask(PipelineStageFlags2::BOTTOM_OF_PIPE)
             .dst_access_mask(AccessFlags2::NONE_KHR)
             .dst_queue_family_index(QUEUE_FAMILY_IGNORED)

--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -152,8 +152,7 @@ impl AddToCommandBuffer for DecodeH264 {
             .src_buffer_offset(self.decode_info.offset)
             .src_buffer_range(self.decode_info.size)
             // .src_buffer_range(2736)
-            .dst_picture_resource(picture_resource_dst)
-            .setup_reference_slot(&video_reference_slot);
+            .dst_picture_resource(picture_resource_dst);
 
         let ssr = ImageSubresourceRange::default()
             .aspect_mask(ImageAspectFlags::COLOR)

--- a/src/video/session.rs
+++ b/src/video/session.rs
@@ -74,8 +74,8 @@ impl VideoSessionShared {
             .picture_format(Format::G8_B8R8_2PLANE_420_UNORM)
             .max_coded_extent(Extent2D { width: 512, height: 512 })
             .reference_picture_format(Format::G8_B8R8_2PLANE_420_UNORM)
-            .max_dpb_slots(17)
-            .max_active_reference_pictures(16)
+            .max_dpb_slots(0)
+            .max_active_reference_pictures(0)
             .std_header_version(&extensions_names);
 
         let result = unsafe {


### PR DESCRIPTION
I am trying to fix #8.  As far as I understand, all DPB slots are required to be "active" for decoding to succeed.  DPB slots can only be activated by decoding a video frame into one.  My idea is to disable DPB slots altogether for decoding the first video frame, since the Vulkan spec states that is valid.  The VideoSession can then be updated to enable DPB slots on the subsequent frames.

This contains the following changes:
- Configure VideoSession with 0 DPB slots
- Change the image layout of native_image_dst to VIDEO_DECODE_DST_KHR

Doing so produces a new error:
```
Error: Vulkan(ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR)
```

1. Do you think I'm on the right track here?
2. Why are the parameters invalid now?
3. Were they never valid in the first place?
4. Is there any way to see a more detailed error message?
5. How did you figure out what parameter values to use?