### PR TITLE
Mark the copy of video_reference_slot in reference_slots as "inactive"

### DIFF
--- a/src/ops/decodeh264.rs
+++ b/src/ops/decodeh264.rs
@@ -117,9 +117,14 @@ impl AddToCommandBuffer for DecodeH264 {
             .slot_index(0)
             .picture_resource(picture_resource_choice);
 
+        let mut reference_slots = [video_reference_slot];
+        // mark the copy of video_reference_slot in reference_slots as "inactive"
+        reference_slots[0].slot_index = -1;
+
         let begin_coding_info = VideoBeginCodingInfoKHR::default()
             .video_session(native_video_session)
-            .video_session_parameters(native_video_session_parameters);
+            .video_session_parameters(native_video_session_parameters)
+            .reference_slots(&reference_slots);
 
         let end_coding_info = VideoEndCodingInfoKHR::default();
 


### PR DESCRIPTION
Closes #8.

THIS TOOK ALL YEAR TO FIX!!!
THANK YOU FFMPEG!!!