### PR TITLE
Fix `copy_image_to_buffer` validation error

### DIFF
--- a/src/ops/copyi2b.rs
+++ b/src/ops/copyi2b.rs
@@ -2,7 +2,10 @@ use crate::error::Error;
 use crate::ops::AddToCommandBuffer;
 use crate::queue::CommandBuilder;
 use crate::resources::{Buffer, BufferShared, Image, ImageShared};
-use ash::vk::{BufferImageCopy, ImageAspectFlags, ImageLayout, ImageSubresourceLayers};
+use ash::vk::{
+    AccessFlags2, BufferImageCopy, DependencyInfoKHR, ImageAspectFlags, ImageLayout, ImageMemoryBarrier2, ImageSubresourceLayers,
+    ImageSubresourceRange, PipelineStageFlags2, QUEUE_FAMILY_IGNORED,
+};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -38,8 +41,45 @@ impl AddToCommandBuffer for CopyImage2Buffer {
             .image_extent(image_info.get_extent())
             .image_subresource(srl);
 
+        let ssr = ImageSubresourceRange::default()
+            .aspect_mask(ImageAspectFlags::COLOR)
+            .level_count(1)
+            .layer_count(1);
+
+        let barrier_acquire = ImageMemoryBarrier2::default()
+            .src_stage_mask(PipelineStageFlags2::NONE)
+            .src_access_mask(AccessFlags2::NONE)
+            .src_queue_family_index(QUEUE_FAMILY_IGNORED)
+            .old_layout(ImageLayout::UNDEFINED)
+            .dst_stage_mask(PipelineStageFlags2::COPY)
+            .dst_access_mask(AccessFlags2::NONE)
+            .dst_queue_family_index(QUEUE_FAMILY_IGNORED)
+            .new_layout(ImageLayout::GENERAL)
+            .image(native_image)
+            .subresource_range(ssr);
+
+        let barrier_release = ImageMemoryBarrier2::default()
+            .src_stage_mask(PipelineStageFlags2::COPY)
+            .src_access_mask(AccessFlags2::NONE)
+            .src_queue_family_index(QUEUE_FAMILY_IGNORED)
+            .old_layout(ImageLayout::GENERAL)
+            .dst_stage_mask(PipelineStageFlags2::BOTTOM_OF_PIPE)
+            .dst_access_mask(AccessFlags2::NONE_KHR)
+            .dst_queue_family_index(QUEUE_FAMILY_IGNORED)
+            .new_layout(ImageLayout::GENERAL)
+            .image(native_image)
+            .subresource_range(ssr);
+
+        let acquire_barriers = &[barrier_acquire];
+        let release_barriers = &[barrier_release];
+
+        let dependency_info_acquire = DependencyInfoKHR::default().image_memory_barriers(acquire_barriers);
+        let dependency_info_release = DependencyInfoKHR::default().image_memory_barriers(release_barriers);
+
         unsafe {
+            native_device.cmd_pipeline_barrier2(native_command_buffer, &dependency_info_acquire);
             native_device.cmd_copy_image_to_buffer(native_command_buffer, native_image, ImageLayout::GENERAL, native_buffer, &[copy]);
+            native_device.cmd_pipeline_barrier2(native_command_buffer, &dependency_info_release);
             Ok(())
         }
     }


### PR DESCRIPTION
Closes #36.

I really don't know what I'm doing here, I just copied code from decodeh264 and changed it until the errors went away.  Is a barrier really necessary here?